### PR TITLE
test: fix failing tests to match new error format

### DIFF
--- a/web/src/app/api/categories/route.test.ts
+++ b/web/src/app/api/categories/route.test.ts
@@ -12,7 +12,6 @@ const { GET, POST } = await import('./route')
 
 describe('GET /api/categories', () => {
   it('returns all categories successfully', async () => {
-    const request = createMockRequest('http://localhost:3000/api/categories')
     const response = await GET()
 
     expect(response.status).toBe(200)
@@ -100,8 +99,11 @@ describe('POST /api/categories', () => {
 
     const data = await getResponseJson(response)
     expect(data).toHaveProperty('error')
-    expect(data.error).toHaveProperty('fieldErrors')
-    expect(data.error.fieldErrors).toHaveProperty('name')
+    expect(data).toHaveProperty('code')
+    expect(data.code).toBe('VALIDATION_ERROR')
+    expect(data).toHaveProperty('details')
+    expect(data.details).toHaveProperty('fieldErrors')
+    expect(data.details.fieldErrors).toHaveProperty('name')
   })
 
   it('returns 400 for empty name', async () => {
@@ -123,7 +125,7 @@ describe('POST /api/categories', () => {
     expect(data).toHaveProperty('error')
   })
 
-  it('returns 400 for invalid JSON payload', async () => {
+  it('returns 500 for invalid JSON payload', async () => {
     const request = new Request('http://localhost:3000/api/categories', {
       method: 'POST',
       headers: {
@@ -132,7 +134,14 @@ describe('POST /api/categories', () => {
       body: 'invalid json',
     })
 
-    await expect(POST(request)).rejects.toThrow()
+    const response = await POST(request)
+
+    expect(response.status).toBe(500)
+
+    const data = await getResponseJson(response)
+    expect(data).toHaveProperty('error')
+    expect(data).toHaveProperty('code')
+    expect(data.code).toBe('INTERNAL_ERROR')
   })
 
   it('returns 400 for wrong data types', async () => {

--- a/web/src/app/api/import/route.test.ts
+++ b/web/src/app/api/import/route.test.ts
@@ -140,8 +140,11 @@ describe('POST /api/import', () => {
 
     const data = await getResponseJson(response)
     expect(data).toHaveProperty('error')
-    expect(data.error).toHaveProperty('fieldErrors')
-    expect(data.error.fieldErrors).toHaveProperty('statementName')
+    expect(data).toHaveProperty('code')
+    expect(data.code).toBe('VALIDATION_ERROR')
+    expect(data).toHaveProperty('details')
+    expect(data.details).toHaveProperty('fieldErrors')
+    expect(data.details.fieldErrors).toHaveProperty('statementName')
   })
 
   it('returns 400 for invalid month format', async () => {
@@ -208,8 +211,11 @@ describe('POST /api/import', () => {
     const data = await getResponseJson(response)
     expect(data).toHaveProperty('error')
     expect(data.error).toContain('already imported')
-    expect(data).toHaveProperty('duplicate')
-    expect(data.duplicate.run_id).toBe('run-existing-123')
+    expect(data).toHaveProperty('code')
+    expect(data.code).toBe('DUPLICATE')
+    expect(data).toHaveProperty('details')
+    expect(data.details).toHaveProperty('duplicate')
+    expect(data.details.duplicate.run_id).toBe('run-existing-123')
   })
 
   it('returns 409 when duplicate statement is pending', async () => {
@@ -236,8 +242,11 @@ describe('POST /api/import', () => {
 
     const data = await getResponseJson(response)
     expect(data.error).toContain('already pending approval')
-    expect(data).toHaveProperty('duplicate')
-    expect(data.duplicate.run_id).toBe('run-pending-456')
+    expect(data).toHaveProperty('code')
+    expect(data.code).toBe('DUPLICATE')
+    expect(data).toHaveProperty('details')
+    expect(data.details).toHaveProperty('duplicate')
+    expect(data.details.duplicate.run_id).toBe('run-pending-456')
   })
 
   it('returns 500 when LLM extraction fails', async () => {


### PR DESCRIPTION
Closes #28

## Summary
Fixed 5 failing tests caused by error format mismatch between PR #25 (new error handling) and PR #27 (API tests).

## Changes
Updated test assertions to match the new standardized error response format:
- **Validation errors**: `fieldErrors` now in `details.fieldErrors`
- **Duplicate errors**: duplicate data now in `details.duplicate`  
- **Invalid JSON**: now returns 500 with `INTERNAL_ERROR` code instead of throwing

## Test Results
✅ All 118 tests passing
✅ No new lint warnings introduced
✅ Type check passes

## Files Changed
- [`src/app/api/categories/route.test.ts`](web/src/app/api/categories/route.test.ts): Fixed 2 tests
- [`src/app/api/import/route.test.ts`](web/src/app/api/import/route.test.ts): Fixed 3 tests