### PR TITLE
feat(imports): add import history page with delete functionality

### DIFF
--- a/web/src/app/api/import/runs/[runId]/route.test.ts
+++ b/web/src/app/api/import/runs/[runId]/route.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+import { createMockRequest, getResponseJson } from '@/test/api-test-utils'
+
+// Mock auth to return test user
+vi.mock('@/lib/auth', () => ({
+  requireUserId: vi.fn().mockResolvedValue('test-user-id'),
+}))
+
+// Mock data-store
+vi.mock('@/lib/data-store', () => ({
+  getImportRunById: vi.fn(),
+  deleteImportRun: vi.fn(),
+  deleteTransactionsByStatementRef: vi.fn(),
+}))
+
+// Import after mocking
+const { DELETE, GET } = await import('./route')
+
+describe('DELETE /api/import/runs/[runId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deletes import run and associated transactions successfully', async () => {
+    const { getImportRunById, deleteImportRun, deleteTransactionsByStatementRef } = vi.mocked(
+      await import('@/lib/data-store'),
+    )
+
+    getImportRunById.mockResolvedValueOnce({
+      run_id: 'run-123',
+      statement_file: 'january-2024.pdf',
+      card_id: 'card-123',
+      month: '2024-01',
+      imported_at: '2024-01-15T10:00:00Z',
+      status: 'completed' as const,
+      summary: {
+        transactions: 10,
+        total_spend: 1500,
+        currency: 'TRY',
+      },
+    })
+
+    deleteTransactionsByStatementRef.mockResolvedValueOnce(10)
+    deleteImportRun.mockResolvedValueOnce(undefined)
+
+    const request = createMockRequest('http://localhost:3000/api/import/runs/run-123', {
+      method: 'DELETE',
+    })
+
+    const context = { params: Promise.resolve({ runId: 'run-123' }) }
+    const response = await DELETE(request as unknown as NextRequest, context)
+
+    expect(response.status).toBe(200)
+
+    const data = await getResponseJson(response)
+    expect(data.ok).toBe(true)
+    expect(data.deleted.runId).toBe('run-123')
+    expect(data.deleted.transactionsCount).toBe(10)
+
+    expect(getImportRunById).toHaveBeenCalledWith('test-user-id', 'run-123')
+    expect(deleteTransactionsByStatementRef).toHaveBeenCalledWith('test-user-id', 'january-2024.pdf')
+    expect(deleteImportRun).toHaveBeenCalledWith('test-user-id', 'run-123')
+  })
+
+  it('returns 404 when import run is not found', async () => {
+    const { getImportRunById } = vi.mocked(await import('@/lib/data-store'))
+
+    getImportRunById.mockResolvedValueOnce(null)
+
+    const request = createMockRequest('http://localhost:3000/api/import/runs/non-existent', {
+      method: 'DELETE',
+    })
+
+    const context = { params: Promise.resolve({ runId: 'non-existent' }) }
+    const response = await DELETE(request as unknown as NextRequest, context)
+
+    expect(response.status).toBe(404)
+
+    const data = await getResponseJson(response)
+    expect(data.error).toContain('not found')
+    expect(data.code).toBe('NOT_FOUND')
+  })
+
+  it('handles database errors gracefully', async () => {
+    const { getImportRunById, deleteTransactionsByStatementRef } = vi.mocked(
+      await import('@/lib/data-store'),
+    )
+
+    getImportRunById.mockResolvedValueOnce({
+      run_id: 'run-123',
+      statement_file: 'january-2024.pdf',
+      card_id: 'card-123',
+      month: '2024-01',
+      imported_at: '2024-01-15T10:00:00Z',
+      status: 'completed' as const,
+    })
+
+    deleteTransactionsByStatementRef.mockRejectedValueOnce(new Error('Database error'))
+
+    const request = createMockRequest('http://localhost:3000/api/import/runs/run-123', {
+      method: 'DELETE',
+    })
+
+    const context = { params: Promise.resolve({ runId: 'run-123' }) }
+    const response = await DELETE(request as unknown as NextRequest, context)
+
+    expect(response.status).toBe(500)
+
+    const data = await getResponseJson(response)
+    expect(data.error).toBe('Database error')
+  })
+})
+
+describe('GET /api/import/runs/[runId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns import run details successfully', async () => {
+    const { getImportRunById } = vi.mocked(await import('@/lib/data-store'))
+
+    const mockRun = {
+      run_id: 'run-123',
+      statement_file: 'january-2024.pdf',
+      card_id: 'card-123',
+      month: '2024-01',
+      imported_at: '2024-01-15T10:00:00Z',
+      status: 'completed' as const,
+      summary: {
+        transactions: 10,
+        total_spend: 1500,
+        currency: 'TRY',
+      },
+    }
+
+    getImportRunById.mockResolvedValueOnce(mockRun)
+
+    const request = createMockRequest('http://localhost:3000/api/import/runs/run-123', {
+      method: 'GET',
+    })
+
+    const context = { params: Promise.resolve({ runId: 'run-123' }) }
+    const response = await GET(request as unknown as NextRequest, context)
+
+    expect(response.status).toBe(200)
+
+    const data = await getResponseJson(response)
+    expect(data.run_id).toBe('run-123')
+    expect(data.statement_file).toBe('january-2024.pdf')
+    expect(data.summary.transactions).toBe(10)
+  })
+
+  it('returns 404 when import run is not found', async () => {
+    const { getImportRunById } = vi.mocked(await import('@/lib/data-store'))
+
+    getImportRunById.mockResolvedValueOnce(null)
+
+    const request = createMockRequest('http://localhost:3000/api/import/runs/non-existent', {
+      method: 'GET',
+    })
+
+    const context = { params: Promise.resolve({ runId: 'non-existent' }) }
+    const response = await GET(request as unknown as NextRequest, context)
+
+    expect(response.status).toBe(404)
+
+    const data = await getResponseJson(response)
+    expect(data.error).toContain('not found')
+    expect(data.code).toBe('NOT_FOUND')
+  })
+})

--- a/web/src/app/api/import/runs/[runId]/route.ts
+++ b/web/src/app/api/import/runs/[runId]/route.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from "next/server";
+
+import {
+  getImportRunById,
+  deleteImportRun,
+  deleteTransactionsByStatementRef,
+} from "@/lib/data-store";
+import { errorResponse, successResponse } from "@/lib/api-utils";
+import { requireUserId } from "@/lib/auth";
+import { ErrorFactory } from "@/lib/errors";
+
+/**
+ * DELETE /api/import/runs/[runId]
+ * Delete an import run and all associated transactions
+ */
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: { runId: string } | Promise<{ runId: string }> },
+) {
+  try {
+    const userId = await requireUserId();
+    const params = await context.params;
+    const runId = params.runId;
+
+    // Get the import run to find the statement_file
+    const importRun = await getImportRunById(userId, runId);
+    if (!importRun) {
+      throw ErrorFactory.notFound(`Import run ${runId}`);
+    }
+
+    // Delete all transactions with matching statement_ref
+    const deletedTransactions = await deleteTransactionsByStatementRef(
+      userId,
+      importRun.statement_file,
+    );
+
+    // Delete the import run record
+    await deleteImportRun(userId, runId);
+
+    return successResponse({
+      ok: true,
+      deleted: {
+        runId,
+        transactionsCount: deletedTransactions,
+      },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+/**
+ * GET /api/import/runs/[runId]
+ * Get details of a specific import run
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: { runId: string } | Promise<{ runId: string }> },
+) {
+  try {
+    const userId = await requireUserId();
+    const params = await context.params;
+    const runId = params.runId;
+
+    const importRun = await getImportRunById(userId, runId);
+    if (!importRun) {
+      throw ErrorFactory.notFound(`Import run ${runId}`);
+    }
+
+    return successResponse(importRun);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/web/src/app/imports/history/page.tsx
+++ b/web/src/app/imports/history/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+import ImportHistoryView from "@/components/imports/import-history-view";
+import { getImportHistory } from "@/lib/data-store";
+import { getServerSession } from "@/lib/auth";
+
+// Force dynamic rendering to prevent build-time database access
+export const dynamic = "force-dynamic";
+
+export default async function ImportHistoryPage() {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+  const userId = session.user.id;
+
+  const history = await getImportHistory(userId);
+  return <ImportHistoryView initialHistory={history} />;
+}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { href: "/transactions", label: "Transactions" },
   { href: "/imports", label: "Imports" },
   { href: "/imports/pending", label: "Pending" },
+  { href: "/imports/history", label: "History" },
   { href: "/categories", label: "Categories" },
 ];
 

--- a/web/src/components/imports/import-history-view.tsx
+++ b/web/src/components/imports/import-history-view.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState } from "react";
+import useSWR from "swr";
+import { format } from "date-fns";
+
+import type { ImportRun } from "@/lib/types";
+
+type Props = {
+  initialHistory: ImportRun[];
+};
+
+type HistoryResponse = {
+  history: ImportRun[];
+};
+
+const fetcher = (url: string) =>
+  fetch(url).then((res) => {
+    if (!res.ok) {
+      throw new Error("Failed to load import history");
+    }
+    return res.json();
+  });
+
+function formatMoney(amount: number, currency: string) {
+  try {
+    return new Intl.NumberFormat("tr-TR", {
+      style: "currency",
+      currency,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+export default function ImportHistoryView({ initialHistory }: Props) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const { data, mutate, isLoading } = useSWR<HistoryResponse>(
+    "/api/import/history",
+    fetcher,
+    { fallbackData: { history: initialHistory } },
+  );
+
+  const history = data?.history ?? [];
+
+  async function handleDelete(runId: string) {
+    setDeletingId(runId);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await fetch(`/api/import/runs/${runId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Failed to delete import run");
+      }
+      const body = await res.json();
+      setSuccess(
+        `Deleted import run ${runId} and ${body.deleted?.transactionsCount ?? 0} transactions.`,
+      );
+      setConfirmDeleteId(null);
+      await mutate();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  function confirmDelete(runId: string) {
+    setConfirmDeleteId(runId);
+    setError(null);
+    setSuccess(null);
+  }
+
+  function cancelDelete() {
+    setConfirmDeleteId(null);
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">Import history</h1>
+        <p className="text-sm text-slate-500">
+          View all completed statement imports. You can delete an import to remove all associated transactions.
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+          {success}
+        </div>
+      )}
+
+      {history.length === 0 ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+          {isLoading ? "Loading import history..." : "No imports found. Import a statement to get started."}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {history.map((run) => (
+            <div
+              key={run.run_id}
+              className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+            >
+              <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+                <div>
+                  <p className="text-sm font-medium text-slate-500">Run ID</p>
+                  <p className="font-mono text-slate-900">{run.run_id}</p>
+                </div>
+                <div className="text-sm text-slate-500">
+                  <p>
+                    Imported on {format(new Date(run.imported_at), "PPpp")}
+                  </p>
+                  <p>
+                    Statement: <span className="font-medium text-slate-900">{run.statement_file}</span>
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Transactions</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                    {run.summary?.transactions ?? 0}
+                  </p>
+                  <p className="text-xs text-slate-500">{run.month}</p>
+                </div>
+                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Total spend</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                    {run.summary
+                      ? formatMoney(run.summary.total_spend, run.summary.currency)
+                      : "-"}
+                  </p>
+                  <p className="text-xs text-slate-500">Net of refunds</p>
+                </div>
+                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Status</p>
+                  <p className="mt-2 text-sm font-medium text-slate-900 capitalize">
+                    {run.status}
+                  </p>
+                  <p className="text-xs text-slate-500">Card: {run.card_id}</p>
+                </div>
+              </div>
+
+              {run.error && (
+                <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                  <p className="font-medium">Error</p>
+                  <p>{run.error}</p>
+                </div>
+              )}
+
+              {/* Delete confirmation dialog */}
+              {confirmDeleteId === run.run_id ? (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-4">
+                  <p className="text-sm font-medium text-amber-800">
+                    Are you sure you want to delete this import?
+                  </p>
+                  <p className="mt-1 text-sm text-amber-700">
+                    This will permanently delete the import run and all {run.summary?.transactions ?? 0} associated transactions.
+                    This action cannot be undone.
+                  </p>
+                  <div className="mt-4 flex flex-col gap-3 md:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(run.run_id)}
+                      disabled={deletingId === run.run_id}
+                      className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+                    >
+                      {deletingId === run.run_id ? "Deleting..." : "Yes, delete import"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelDelete}
+                      disabled={deletingId === run.run_id}
+                      className="rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end">
+                  <button
+                    type="button"
+                    onClick={() => confirmDelete(run.run_id)}
+                    className="rounded-md border border-red-300 px-4 py-2 text-sm font-semibold text-red-600 shadow-sm transition hover:bg-red-50 min-h-11 w-full md:w-auto"
+                  >
+                    Delete import
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/db/repositories/import-runs.ts
+++ b/web/src/db/repositories/import-runs.ts
@@ -190,3 +190,35 @@ export async function loadPendingExtractionWithMeta(
     savedAt: result[0].savedAt,
   };
 }
+
+/**
+ * Get an import run by ID
+ */
+export async function getImportRunById(
+  userId: string,
+  runId: string,
+): Promise<ImportRun | null> {
+  const result = await db
+    .select()
+    .from(importRuns)
+    .where(and(eq(importRuns.runId, runId), eq(importRuns.userId, userId)))
+    .limit(1);
+
+  if (result.length === 0) {
+    return null;
+  }
+
+  return toApiType(result[0]);
+}
+
+/**
+ * Delete an import run
+ */
+export async function deleteImportRun(
+  userId: string,
+  runId: string,
+): Promise<void> {
+  await db
+    .delete(importRuns)
+    .where(and(eq(importRuns.runId, runId), eq(importRuns.userId, userId)));
+}

--- a/web/src/db/repositories/transactions.ts
+++ b/web/src/db/repositories/transactions.ts
@@ -232,3 +232,32 @@ export async function getTransactionById(
 
   return toApiType(result[0]);
 }
+
+/**
+ * Delete transactions by statement reference
+ */
+export async function deleteTransactionsByStatementRef(
+  userId: string,
+  statementRef: string,
+): Promise<number> {
+  const result = await db
+    .delete(transactions)
+    .where(and(eq(transactions.userId, userId), eq(transactions.statementRef, statementRef)));
+
+  return result.rowsAffected ?? 0;
+}
+
+/**
+ * Count transactions by statement reference
+ */
+export async function countTransactionsByStatementRef(
+  userId: string,
+  statementRef: string,
+): Promise<number> {
+  const result = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(and(eq(transactions.userId, userId), eq(transactions.statementRef, statementRef)));
+
+  return result.length;
+}

--- a/web/src/lib/data-store.ts
+++ b/web/src/lib/data-store.ts
@@ -124,3 +124,19 @@ export async function loadPendingExtractionWithMeta(
 ): Promise<{ data: unknown; savedAt: string } | null> {
   return importRunsRepo.loadPendingExtractionWithMeta(userId, runId);
 }
+
+export async function getImportRunById(userId: string, runId: string): Promise<ImportRun | null> {
+  return importRunsRepo.getImportRunById(userId, runId);
+}
+
+export async function deleteImportRun(userId: string, runId: string): Promise<void> {
+  await importRunsRepo.deleteImportRun(userId, runId);
+}
+
+export async function deleteTransactionsByStatementRef(userId: string, statementRef: string): Promise<number> {
+  return transactionsRepo.deleteTransactionsByStatementRef(userId, statementRef);
+}
+
+export async function countTransactionsByStatementRef(userId: string, statementRef: string): Promise<number> {
+  return transactionsRepo.countTransactionsByStatementRef(userId, statementRef);
+}


### PR DESCRIPTION
## Summary
- Adds `/imports/history` page showing all import runs for the user
- Adds `DELETE /api/import/runs/[runId]` endpoint that deletes the import_run record and all transactions with matching statement_ref
- Adds delete button with confirmation dialog on each import row
- All operations are user-scoped (only show/delete own data)
- Adds navigation link to History in the app shell

## Test plan
- [ ] Navigate to `/imports/history` and verify import history is displayed
- [ ] Verify each import shows run ID, statement file, date, transactions count, and total spend
- [ ] Click "Delete import" button and verify confirmation dialog appears
- [ ] Confirm deletion and verify both import run and associated transactions are deleted
- [ ] Cancel deletion and verify no changes occur
- [ ] Verify only the current user's imports are shown
- [ ] Run `npm run test` and verify all tests pass
- [ ] Run `npm run type-check` and verify no type errors

Closes #43

Generated with [Claude Code](https://claude.com/claude-code)