### PR TITLE
fix(llm): ensure full transaction extraction from multi-page statements

### DIFF
--- a/web/src/lib/llm.ts
+++ b/web/src/lib/llm.ts
@@ -177,6 +177,9 @@ Rules:
 - Provide statement summary totals and currency.
 - Include warnings for ambiguous rows.
 - Extract metadata from statement: statement date (to determine month), card last 4 digits, and cardholder name.
+- You MUST extract ALL transactions from the statement - do not skip any.
+- Do not summarize or truncate the transaction list.
+- If there are many transactions, include every single one.
 `;
 
 function buildPrompt(input: StatementExtractionPrompt): string {
@@ -246,6 +249,8 @@ ${input.statementText}
 
 Schema (for reference):
 ${JSON.stringify(schema, null, 2)}
+
+IMPORTANT: Extract every transaction. The statement may have 50-100+ transactions. Do not skip, summarize, or truncate any transactions.
 `;
 }
 
@@ -423,6 +428,7 @@ export async function extractTransactionsWithLLM(
         const completionParams: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming = {
           model,
           response_format: { type: "json_object" },
+          max_tokens: 16000, // Allow longer outputs for statements with many transactions (50-100+)
           messages: [
             { role: "system", content: SYSTEM_PROMPT },
             { role: "user", content: buildPrompt(input) },
@@ -472,6 +478,17 @@ export async function extractTransactionsWithLLM(
           LLMErrorCode.VALIDATION_FAILED,
           { retryable: false, details: validationResult.error.issues }
         );
+      }
+
+      // Check for transaction count mismatch between reported summary and actual extracted transactions
+      const reportedCount = validationResult.data.summary.transactions;
+      const actualCount = validationResult.data.transactions.length;
+      if (reportedCount !== actualCount) {
+        const mismatchWarning = `Transaction count mismatch: summary reports ${reportedCount} transactions but only ${actualCount} were extracted. Some transactions may have been missed.`;
+        llmLogger.warn({ reportedCount, actualCount }, mismatchWarning);
+        // Add warning to the result
+        validationResult.data.warnings = validationResult.data.warnings || [];
+        validationResult.data.warnings.push(mismatchWarning);
       }
 
       // Log successful completion with token usage


### PR DESCRIPTION
## Summary
- Add explicit instructions in SYSTEM_PROMPT to extract ALL transactions without skipping
- Add emphasis in buildPrompt to not summarize or truncate transactions
- Set max_tokens to 16000 to allow longer outputs for statements with 50-100+ transactions
- Add validation check to warn when reported transaction count differs from actual extracted count

## Problem
The LLM was only extracting 7 transactions from an 85-transaction PDF statement (Issue #47).

## Changes Made
1. **Updated SYSTEM_PROMPT** - Added explicit instructions:
   - "You MUST extract ALL transactions from the statement - do not skip any"
   - "Do not summarize or truncate the transaction list"
   - "If there are many transactions, include every single one"

2. **Updated buildPrompt function** - Added emphasis at the end of the prompt:
   - "IMPORTANT: Extract every transaction. The statement may have 50-100+ transactions. Do not skip, summarize, or truncate any transactions."

3. **Added max_tokens parameter** - Set to 16000 to allow longer outputs for statements with many transactions

4. **Added validation check** - Compares `summary.transactions` (reported count) with `transactions.length` (actual extracted count) and logs a warning if they differ

## Test plan
- [x] Run `npm run type-check` - passes
- [x] Run `npm run test` - all 134 tests pass

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)