### PR TITLE
feat(ui): add loading spinners and skeleton components

### DIFF
--- a/web/src/components/categories/categories-manager.tsx
+++ b/web/src/components/categories/categories-manager.tsx
@@ -4,6 +4,8 @@ import { FormEvent, useState } from "react";
 import useSWR from "swr";
 
 import type { Category } from "@/lib/types";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState, TagIcon } from "@/components/ui/empty-state";
 
 type Props = {
   initialCategories: Category[];
@@ -164,9 +166,25 @@ export default function CategoriesManager({ initialCategories }: Props) {
 
       <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
         {isLoading && categories.length === 0 ? (
-          <p className="text-sm text-slate-500">Loading categories...</p>
+          <div className="space-y-3" aria-busy="true">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 py-2">
+                <Skeleton className="h-8 w-12 rounded" />
+                <Skeleton className="h-8 flex-1 rounded-md" />
+                <Skeleton className="h-4 w-32 rounded" />
+                <div className="flex gap-2">
+                  <Skeleton className="h-8 w-16 rounded-md" />
+                  <Skeleton className="h-8 w-16 rounded-md" />
+                </div>
+              </div>
+            ))}
+          </div>
         ) : categories.length === 0 ? (
-          <p className="text-sm text-slate-500">No categories configured yet.</p>
+          <EmptyState
+            icon={<TagIcon />}
+            title="No categories yet"
+            description="Categories help organize your transactions. Add your first category above, or they will be created automatically when you import statements."
+          />
         ) : (
           <>
             {/* Mobile card view */}

--- a/web/src/components/dashboard/dashboard-view.tsx
+++ b/web/src/components/dashboard/dashboard-view.tsx
@@ -9,6 +9,13 @@ import HeroMetrics from "./hero-metrics";
 import SpendingTrendChart from "./spending-trend-chart";
 import TopCategories from "./top-categories";
 import RecentTransactions from "./recent-transactions";
+import DashboardEmpty from "./dashboard-empty";
+import Spinner from "@/components/ui/spinner";
+import {
+  SkeletonHeroMetrics,
+  SkeletonChart,
+  SkeletonCategoryList,
+} from "@/components/ui/skeleton";
 
 type Props = {
   summary: DashboardSummary | null;
@@ -70,12 +77,33 @@ export default function DashboardView({ summary, months }: Props) {
     );
   }
 
-  if (!activeSummary) {
+  // Show skeleton loading state when switching months
+  if (isLoading && !activeSummary) {
     return (
-      <div className="rounded-xl bg-white p-8 text-center shadow-sm">
-        <p className="text-slate-500">No data available yet. Import a statement to get started.</p>
+      <div className="space-y-8">
+        {/* Header skeleton */}
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+          <div>
+            <div className="h-8 w-48 animate-pulse rounded-md bg-slate-200" />
+            <div className="mt-2 h-4 w-32 animate-pulse rounded-md bg-slate-200" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Spinner size="sm" />
+            <div className="h-10 w-48 animate-pulse rounded-xl bg-slate-200" />
+          </div>
+        </div>
+        <SkeletonHeroMetrics />
+        <SkeletonChart />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SkeletonCategoryList count={5} />
+          <SkeletonCategoryList count={5} />
+        </div>
       </div>
     );
+  }
+
+  if (!activeSummary) {
+    return <DashboardEmpty />;
   }
 
   return (
@@ -95,7 +123,7 @@ export default function DashboardView({ summary, months }: Props) {
         </div>
         <div className="flex items-center gap-2">
           {isLoading && (
-            <span className="text-xs text-slate-400">Refreshing...</span>
+            <Spinner size="sm" label="Refreshing..." />
           )}
           <select
             value={selectedMonth}

--- a/web/src/components/imports/import-history-view.tsx
+++ b/web/src/components/imports/import-history-view.tsx
@@ -5,6 +5,8 @@ import useSWR from "swr";
 import { format } from "date-fns";
 
 import type { ImportRun } from "@/lib/types";
+import { SkeletonImportCard } from "@/components/ui/skeleton";
+import { EmptyState, ClockIcon } from "@/components/ui/empty-state";
 
 type Props = {
   initialHistory: ImportRun[];
@@ -102,10 +104,22 @@ export default function ImportHistoryView({ initialHistory }: Props) {
         </div>
       )}
 
-      {history.length === 0 ? (
-        <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
-          {isLoading ? "Loading import history..." : "No imports found. Import a statement to get started."}
+      {isLoading && history.length === 0 ? (
+        <div className="space-y-4" aria-busy="true">
+          <SkeletonImportCard />
+          <SkeletonImportCard />
+          <SkeletonImportCard />
         </div>
+      ) : history.length === 0 ? (
+        <EmptyState
+          icon={<ClockIcon />}
+          title="No imports yet"
+          description="Your import history will appear here once you upload and approve your first credit card statement."
+          action={{
+            label: "Upload Statement",
+            href: "/imports",
+          }}
+        />
       ) : (
         <div className="space-y-4">
           {history.map((run) => (

--- a/web/src/components/imports/pending-imports-view.tsx
+++ b/web/src/components/imports/pending-imports-view.tsx
@@ -5,6 +5,8 @@ import useSWR from "swr";
 import { format } from "date-fns";
 
 import type { PendingRunSummary, PendingRunDetail } from "@/lib/importer";
+import { SkeletonImportCard } from "@/components/ui/skeleton";
+import { EmptyState, InboxIcon } from "@/components/ui/empty-state";
 
 type Props = {
   initialRuns: PendingRunSummary[];
@@ -144,10 +146,21 @@ export default function PendingImportsView({ initialRuns }: Props) {
         </div>
       )}
 
-      {runs.length === 0 ? (
-        <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
-          {isLoading ? "Loading pending runs..." : "No pending imports waiting for approval."}
+      {isLoading && runs.length === 0 ? (
+        <div className="space-y-4" aria-busy="true">
+          <SkeletonImportCard />
+          <SkeletonImportCard />
         </div>
+      ) : runs.length === 0 ? (
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No pending imports"
+          description="When you upload a statement, it will appear here for review before being committed to your ledger."
+          action={{
+            label: "Upload Statement",
+            href: "/imports",
+          }}
+        />
       ) : (
           <div className="space-y-4">
             {runs.map((run) => (

--- a/web/src/components/transactions/transactions-view.tsx
+++ b/web/src/components/transactions/transactions-view.tsx
@@ -5,6 +5,8 @@ import useSWR from "swr";
 import { format } from "date-fns";
 
 import { Card, Category, Owner, TransactionFile, TransactionRecord } from "@/lib/types";
+import { SkeletonTransactionCard } from "@/components/ui/skeleton";
+import { EmptyState, DocumentIcon } from "@/components/ui/empty-state";
 
 type Props = {
   months: string[];
@@ -273,15 +275,28 @@ export default function TransactionsView({
       )}
 
       {isLoading && (
-        <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-500">
-          Loading transactions...
+        <div className="space-y-6">
+          <SkeletonTransactionCard rowCount={6} />
+          <SkeletonTransactionCard rowCount={4} />
         </div>
       )}
 
       {!isLoading && groupedByCard.length === 0 ? (
-        <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
-          No transactions match the current filters.
-        </div>
+        transactions.length === 0 ? (
+          <EmptyState
+            icon={<DocumentIcon />}
+            title="No transactions yet"
+            description="Import your first credit card statement to see your transactions here."
+            action={{
+              label: "Import Statement",
+              href: "/imports",
+            }}
+          />
+        ) : (
+          <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500 text-center">
+            No transactions match the current filters.
+          </div>
+        )
       ) : (
         <div className="space-y-6">
           {groupedByCard.map(({ cardId, card, transactions: rows }) => (

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,242 @@
+import { cn } from "@/lib/utils";
+
+type SkeletonBaseProps = {
+  className?: string;
+};
+
+/**
+ * Base skeleton component with pulse animation.
+ */
+function SkeletonBase({ className }: SkeletonBaseProps) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-slate-200",
+        className
+      )}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Skeleton for metric/stat cards (rounded box with pulse animation).
+ * Matches the hero metrics card design.
+ */
+export function SkeletonCard({ className }: SkeletonBaseProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+        className
+      )}
+      aria-hidden="true"
+    >
+      <SkeletonBase className="mb-3 h-4 w-24" />
+      <SkeletonBase className="h-8 w-32" />
+      <SkeletonBase className="mt-2 h-3 w-16" />
+    </div>
+  );
+}
+
+/**
+ * Skeleton for chart areas.
+ * Displays a larger rectangle mimicking a chart container.
+ */
+export function SkeletonChart({ className }: SkeletonBaseProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+        className
+      )}
+      aria-hidden="true"
+    >
+      <SkeletonBase className="mb-4 h-5 w-40" />
+      <SkeletonBase className="h-64 w-full rounded-lg" />
+    </div>
+  );
+}
+
+/**
+ * Skeleton for table/list rows.
+ * Displays multiple horizontal bars mimicking a table row.
+ */
+export function SkeletonRow({ className }: SkeletonBaseProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-4 py-3",
+        className
+      )}
+      aria-hidden="true"
+    >
+      <SkeletonBase className="h-4 w-20" />
+      <SkeletonBase className="h-4 w-32 flex-1" />
+      <SkeletonBase className="h-4 w-16" />
+      <SkeletonBase className="h-4 w-20" />
+    </div>
+  );
+}
+
+/**
+ * Skeleton for text lines.
+ * Variable widths for natural text appearance.
+ */
+type SkeletonTextProps = SkeletonBaseProps & {
+  lines?: number;
+};
+
+export function SkeletonText({ className, lines = 1 }: SkeletonTextProps) {
+  const widths = ["w-full", "w-3/4", "w-5/6", "w-2/3", "w-4/5"];
+
+  return (
+    <div className={cn("space-y-2", className)} aria-hidden="true">
+      {Array.from({ length: lines }).map((_, i) => (
+        <SkeletonBase
+          key={i}
+          className={cn("h-4", widths[i % widths.length])}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Skeleton wrapper for loading states with smooth fade transition.
+ */
+type SkeletonContainerProps = {
+  isLoading: boolean;
+  skeleton: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export function SkeletonContainer({
+  isLoading,
+  skeleton,
+  children,
+}: SkeletonContainerProps) {
+  if (isLoading) {
+    return <>{skeleton}</>;
+  }
+
+  return (
+    <div className="animate-in fade-in duration-300">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Dashboard-specific skeleton: Hero metrics grid.
+ */
+export function SkeletonHeroMetrics({ className }: SkeletonBaseProps) {
+  return (
+    <div className={cn("grid gap-4 sm:grid-cols-3", className)} aria-hidden="true">
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+    </div>
+  );
+}
+
+/**
+ * Dashboard-specific skeleton: Category list items.
+ */
+export function SkeletonCategoryList({ className, count = 5 }: SkeletonBaseProps & { count?: number }) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-3",
+        className
+      )}
+      aria-hidden="true"
+    >
+      <SkeletonBase className="mb-4 h-5 w-32" />
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <SkeletonBase className="h-4 w-4 rounded-full" />
+          <SkeletonBase className="h-4 flex-1" />
+          <SkeletonBase className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Transactions-specific skeleton: Transaction rows in a card.
+ */
+export function SkeletonTransactionCard({ className, rowCount = 5 }: SkeletonBaseProps & { rowCount?: number }) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm",
+        className
+      )}
+      aria-hidden="true"
+    >
+      {/* Card header */}
+      <div className="flex items-center justify-between border-b border-slate-100 pb-3 mb-3">
+        <div>
+          <SkeletonBase className="h-5 w-32 mb-1" />
+          <SkeletonBase className="h-3 w-20" />
+        </div>
+        <div className="text-right">
+          <SkeletonBase className="h-4 w-24 mb-1" />
+          <SkeletonBase className="h-4 w-20" />
+        </div>
+      </div>
+      {/* Transaction rows */}
+      <div className="space-y-1">
+        {Array.from({ length: rowCount }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Import-specific skeleton: Pending/history cards.
+ */
+export function SkeletonImportCard({ className }: SkeletonBaseProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-4",
+        className
+      )}
+      aria-hidden="true"
+    >
+      {/* Header row */}
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+        <div>
+          <SkeletonBase className="h-4 w-16 mb-1" />
+          <SkeletonBase className="h-5 w-48" />
+        </div>
+        <div>
+          <SkeletonBase className="h-4 w-32 mb-1" />
+          <SkeletonBase className="h-4 w-40" />
+        </div>
+      </div>
+      {/* Stats grid */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+            <SkeletonBase className="h-3 w-20 mb-2" />
+            <SkeletonBase className="h-6 w-16" />
+            <SkeletonBase className="h-3 w-12 mt-1" />
+          </div>
+        ))}
+      </div>
+      {/* Action buttons */}
+      <div className="flex justify-end gap-3">
+        <SkeletonBase className="h-10 w-32 rounded-md" />
+        <SkeletonBase className="h-10 w-28 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+export { SkeletonBase as Skeleton };

--- a/web/src/components/ui/spinner.tsx
+++ b/web/src/components/ui/spinner.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+type SpinnerSize = "sm" | "md" | "lg";
+
+type SpinnerProps = {
+  size?: SpinnerSize;
+  label?: string;
+  className?: string;
+};
+
+const sizeClasses: Record<SpinnerSize, string> = {
+  sm: "h-4 w-4 border-2",
+  md: "h-6 w-6 border-2",
+  lg: "h-8 w-8 border-3",
+};
+
+export function Spinner({ size = "md", label, className }: SpinnerProps) {
+  return (
+    <div
+      className={cn("flex flex-col items-center justify-center gap-2", className)}
+      role="status"
+      aria-label={label ?? "Loading"}
+    >
+      <div
+        className={cn(
+          "animate-spin rounded-full border-slate-200 border-t-slate-600",
+          sizeClasses[size]
+        )}
+      />
+      {label && (
+        <span className="text-sm text-slate-500">{label}</span>
+      )}
+      <span className="sr-only">{label ?? "Loading"}</span>
+    </div>
+  );
+}
+
+export default Spinner;

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Utility for conditionally joining class names.
+ * Simple implementation without external deps.
+ */
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(" ");
+}
+
 export function slugifyId(input: string, prefix = "cat") {
   const normalized = input
     .toLowerCase()


### PR DESCRIPTION
## Summary
- Add reusable Spinner component with sm/md/lg sizes and optional label text
- Add comprehensive Skeleton components (Card, Chart, Row, Text, plus page-specific variants like SkeletonHeroMetrics, SkeletonTransactionCard, SkeletonImportCard)
- Add `cn()` utility function for conditional class name joining
- Update Dashboard, Transactions, Categories, and Import pages to use skeleton loading states instead of plain "Loading..." text

## Test Plan
- [x] TypeScript type-check passes
- [x] ESLint passes (no new errors)
- [x] All 143 tests pass
- [x] Build completes successfully
- [ ] Visual verification of skeleton loading states on each page

Closes #56

---
Generated with [Claude Code](https://claude.com/claude-code)