### PR TITLE
feat(ui): UX Phase 3 - Navigation, Filters, Mobile

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -24,3 +24,17 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Mobile navigation slide-in animation */
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right 0.2s ease-out;
+}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -1,16 +1,50 @@
 'use client';
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ReactNode, useState } from "react";
+import { ReactNode, useState, ComponentType, useEffect, useRef } from "react";
 import { useSession, signOut } from "next-auth/react";
+import {
+  ChartBarIcon,
+  ListBulletIcon,
+  ArrowUpTrayIcon,
+  ClockIcon,
+  ArchiveBoxIcon,
+  TagIcon,
+} from "@/components/ui/icons";
 
-const NAV_ITEMS = [
-  { href: "/", label: "Dashboard" },
-  { href: "/transactions", label: "Transactions" },
-  { href: "/imports", label: "Imports" },
-  { href: "/imports/pending", label: "Pending" },
-  { href: "/imports/history", label: "History" },
-  { href: "/categories", label: "Categories" },
+interface NavItem {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+interface NavGroup {
+  label: string;
+  items: NavItem[];
+}
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: "View",
+    items: [
+      { href: "/", label: "Dashboard", icon: ChartBarIcon },
+      { href: "/transactions", label: "Transactions", icon: ListBulletIcon },
+    ],
+  },
+  {
+    label: "Import",
+    items: [
+      { href: "/imports", label: "Upload", icon: ArrowUpTrayIcon },
+      { href: "/imports/pending", label: "Pending", icon: ClockIcon },
+      { href: "/imports/history", label: "History", icon: ArchiveBoxIcon },
+    ],
+  },
+  {
+    label: "Settings",
+    items: [
+      { href: "/categories", label: "Categories", icon: TagIcon },
+    ],
+  },
 ];
 
 function HamburgerIcon() {
@@ -51,31 +85,128 @@ function CloseIcon() {
   );
 }
 
-function NavigationLink({ href, label, onClick }: { href: string; label: string; onClick?: () => void }) {
-  const pathname = usePathname();
-  const isActive =
-    href === "/"
-      ? pathname === "/" || pathname.startsWith("/dashboard")
-      : href === "/imports"
-        ? pathname === "/imports"
-        : pathname === href || pathname.startsWith(`${href}/`);
-
+function ChevronDownIcon({ className }: { className?: string }) {
   return (
-    <Link
-      href={href}
-      onClick={onClick}
-      className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-        isActive
-          ? "bg-slate-900 text-white"
-          : "text-slate-500 hover:bg-slate-200 hover:text-slate-900"
-      }`}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className || "h-4 w-4"}
     >
-      {label}
-    </Link>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m19.5 8.25-7.5 7.5-7.5-7.5"
+      />
+    </svg>
   );
 }
 
-function MobileNavigationLink({ href, label, onClick }: { href: string; label: string; onClick?: () => void }) {
+function SignOutIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className || "h-5 w-5"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
+    </svg>
+  );
+}
+
+function NavigationDropdown({ group }: { group: NavGroup }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const prevPathnameRef = useRef<string | null>(null);
+  const pathname = usePathname();
+
+  // Check if any item in the group is active
+  const isGroupActive = group.items.some(item => {
+    if (item.href === "/") {
+      return pathname === "/" || pathname.startsWith("/dashboard");
+    }
+    if (item.href === "/imports") {
+      return pathname === "/imports";
+    }
+    return pathname === item.href || pathname.startsWith(`${item.href}/`);
+  });
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Close dropdown on route change - only when pathname actually changes
+  useEffect(() => {
+    if (prevPathnameRef.current !== null && prevPathnameRef.current !== pathname) {
+      // Use queueMicrotask to avoid direct setState in effect body
+      queueMicrotask(() => setIsOpen(false));
+    }
+    prevPathnameRef.current = pathname;
+  }, [pathname]);
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+          isGroupActive
+            ? "bg-slate-800 text-white"
+            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+        }`}
+      >
+        {group.label}
+        <ChevronDownIcon className={`h-3.5 w-3.5 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+          {group.items.map((item) => {
+            const Icon = item.icon;
+            const isActive =
+              item.href === "/"
+                ? pathname === "/" || pathname.startsWith("/dashboard")
+                : item.href === "/imports"
+                  ? pathname === "/imports"
+                  : pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setIsOpen(false)}
+                className={`flex items-center gap-2.5 px-3 py-2.5 text-sm transition-colors ${
+                  isActive
+                    ? "bg-slate-100 text-slate-900 font-medium"
+                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MobileNavigationLink({
+  href,
+  label,
+  icon: Icon,
+  onClick
+}: {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  onClick?: () => void;
+}) {
   const pathname = usePathname();
   const isActive =
     href === "/"
@@ -88,12 +219,13 @@ function MobileNavigationLink({ href, label, onClick }: { href: string; label: s
     <Link
       href={href}
       onClick={onClick}
-      className={`block rounded-md px-4 py-3 text-base font-medium transition-colors min-h-11 ${
+      className={`flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium transition-colors min-h-[44px] ${
         isActive
           ? "bg-slate-900 text-white"
           : "text-slate-700 hover:bg-slate-100"
       }`}
     >
+      <Icon className="h-5 w-5" />
       {label}
     </Link>
   );
@@ -103,9 +235,19 @@ export function AppShell({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const prevPathnameRef = useRef<string | null>(null);
 
-  // Don't show app shell on login page
-  if (pathname === "/login") {
+  // Close mobile menu on route change - only when pathname actually changes
+  useEffect(() => {
+    if (prevPathnameRef.current !== null && prevPathnameRef.current !== pathname) {
+      // Use queueMicrotask to avoid direct setState in effect body
+      queueMicrotask(() => setMobileMenuOpen(false));
+    }
+    prevPathnameRef.current = pathname;
+  }, [pathname]);
+
+  // Don't show app shell on login or signup page
+  if (pathname === "/login" || pathname === "/signup") {
     return <>{children}</>;
   }
 
@@ -120,8 +262,8 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <div className="min-h-screen bg-slate-100">
-      <header className="border-b border-slate-200 bg-white shadow-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 md:px-6">
+      <header className="border-b border-slate-200 bg-white shadow-sm sticky top-0 z-40">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 md:px-6 md:py-4">
           <div>
             <Link href="/" className="text-xl font-semibold text-slate-900">
               Finance Tracker
@@ -129,54 +271,80 @@ export function AppShell({ children }: { children: ReactNode }) {
             <p className="text-sm text-slate-500 hidden sm:block">Monthly credit card insights</p>
           </div>
 
-          {/* Desktop navigation */}
-          <nav className="hidden md:flex items-center gap-2">
-            {NAV_ITEMS.map((item) => (
-              <NavigationLink key={item.href} {...item} />
+          {/* Desktop navigation - grouped dropdowns */}
+          <nav className="hidden md:flex items-center gap-1">
+            {NAV_GROUPS.map((group) => (
+              <NavigationDropdown key={group.label} group={group} />
             ))}
             {session && (
               <button
                 onClick={() => signOut({ callbackUrl: "/login" })}
-                className="ml-4 rounded-md px-3 py-2 text-sm font-medium text-slate-500 hover:bg-slate-200 hover:text-slate-900 transition-colors"
+                className="ml-2 flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-colors"
               >
+                <SignOutIcon className="h-4 w-4" />
                 Sign out
               </button>
             )}
           </nav>
 
-          {/* Mobile hamburger button */}
+          {/* Mobile hamburger button - 44px minimum touch target */}
           <button
             type="button"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             className="md:hidden flex items-center justify-center h-11 w-11 rounded-md text-slate-600 hover:bg-slate-100 transition-colors"
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileMenuOpen}
           >
             {mobileMenuOpen ? <CloseIcon /> : <HamburgerIcon />}
           </button>
         </div>
 
-        {/* Mobile navigation menu */}
+        {/* Mobile navigation menu - full-screen overlay */}
         {mobileMenuOpen && (
-          <nav className="md:hidden border-t border-slate-200 bg-white px-4 py-3 space-y-1">
-            {NAV_ITEMS.map((item) => (
-              <MobileNavigationLink
-                key={item.href}
-                {...item}
-                onClick={() => setMobileMenuOpen(false)}
-              />
-            ))}
-            {session && (
-              <button
-                onClick={() => {
-                  setMobileMenuOpen(false);
-                  signOut({ callbackUrl: "/login" });
-                }}
-                className="block w-full text-left rounded-md px-4 py-3 text-base font-medium text-slate-700 hover:bg-slate-100 transition-colors min-h-11"
-              >
-                Sign out
-              </button>
-            )}
-          </nav>
+          <>
+            {/* Backdrop */}
+            <div
+              className="md:hidden fixed inset-0 top-[57px] bg-black/20 z-40"
+              onClick={() => setMobileMenuOpen(false)}
+            />
+
+            {/* Slide-in drawer */}
+            <nav className="md:hidden fixed right-0 top-[57px] bottom-0 w-72 max-w-[80vw] bg-white z-50 shadow-xl overflow-y-auto animate-slide-in-right">
+              <div className="p-4 space-y-6">
+                {NAV_GROUPS.map((group) => (
+                  <div key={group.label}>
+                    <p className="px-4 py-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      {group.label}
+                    </p>
+                    <div className="space-y-1">
+                      {group.items.map((item) => (
+                        <MobileNavigationLink
+                          key={item.href}
+                          {...item}
+                          onClick={() => setMobileMenuOpen(false)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+
+                {session && (
+                  <div className="pt-4 border-t border-slate-200">
+                    <button
+                      onClick={() => {
+                        setMobileMenuOpen(false);
+                        signOut({ callbackUrl: "/login" });
+                      }}
+                      className="flex items-center gap-3 w-full text-left rounded-md px-4 py-3 text-base font-medium text-slate-700 hover:bg-slate-100 transition-colors min-h-[44px]"
+                    >
+                      <SignOutIcon className="h-5 w-5" />
+                      Sign out
+                    </button>
+                  </div>
+                )}
+              </div>
+            </nav>
+          </>
         )}
       </header>
       <main className="mx-auto max-w-6xl px-4 py-6 md:px-6 md:py-8">{children}</main>

--- a/web/src/components/dashboard/dashboard-view.tsx
+++ b/web/src/components/dashboard/dashboard-view.tsx
@@ -128,7 +128,7 @@ export default function DashboardView({ summary, months }: Props) {
           <select
             value={selectedMonth}
             onChange={(event) => setSelectedMonth(event.target.value)}
-            className="rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-48"
+            className="rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] w-full sm:w-48"
           >
             {months.map((monthOption) => (
               <option key={monthOption} value={monthOption}>

--- a/web/src/components/transactions/transactions-view.tsx
+++ b/web/src/components/transactions/transactions-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
 import { format } from "date-fns";
 
@@ -50,6 +50,62 @@ interface FilterState {
   search?: string;
 }
 
+const FILTER_STORAGE_KEY = "transactions-filters";
+
+function ChevronDownIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className || "h-4 w-4"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+    </svg>
+  );
+}
+
+function XMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className || "h-4 w-4"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+function FunnelIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className || "h-4 w-4"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z" />
+    </svg>
+  );
+}
+
+function MagnifyingGlassIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className || "h-4 w-4"} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+    </svg>
+  );
+}
+
+interface FilterChipProps {
+  label: string;
+  value: string;
+  onRemove: () => void;
+}
+
+function FilterChip({ label, value, onRemove }: FilterChipProps) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm text-slate-700">
+      <span className="text-slate-500">{label}:</span>
+      <span className="font-medium">{value}</span>
+      <button
+        onClick={onRemove}
+        className="ml-0.5 rounded-full p-0.5 hover:bg-slate-200 transition-colors min-h-[22px] min-w-[22px] flex items-center justify-center"
+        aria-label={`Remove ${label} filter`}
+      >
+        <XMarkIcon className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  );
+}
+
 export default function TransactionsView({
   months,
   cards,
@@ -58,15 +114,76 @@ export default function TransactionsView({
   initialMonth,
   initialFile,
 }: Props) {
-  const [filters, setFilters] = useState<FilterState>({
-    month: initialMonth ?? months[0] ?? "",
-    cardId: undefined,
-    ownerId: undefined,
-    categoryId: undefined,
-    search: "",
-  });
+  const [showMoreFilters, setShowMoreFilters] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Load persisted filters from localStorage
+  const getInitialFilters = useCallback((): FilterState => {
+    if (typeof window === "undefined") {
+      return {
+        month: initialMonth ?? months[0] ?? "",
+        cardId: undefined,
+        ownerId: undefined,
+        categoryId: undefined,
+        search: "",
+      };
+    }
+
+    try {
+      const stored = localStorage.getItem(FILTER_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<FilterState>;
+        // Validate month is still available
+        const validMonth = parsed.month && months.includes(parsed.month)
+          ? parsed.month
+          : initialMonth ?? months[0] ?? "";
+        return {
+          month: validMonth,
+          cardId: parsed.cardId,
+          ownerId: parsed.ownerId,
+          categoryId: parsed.categoryId,
+          search: parsed.search || "",
+        };
+      }
+    } catch {
+      // Ignore localStorage errors
+    }
+
+    return {
+      month: initialMonth ?? months[0] ?? "",
+      cardId: undefined,
+      ownerId: undefined,
+      categoryId: undefined,
+      search: "",
+    };
+  }, [initialMonth, months]);
+
+  const [filters, setFilters] = useState<FilterState>(getInitialFilters);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    setFilters(getInitialFilters());
+    setIsHydrated(true);
+  }, [getInitialFilters]);
+
+  // Persist filters to localStorage
+  useEffect(() => {
+    if (!isHydrated) return;
+    try {
+      localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(filters));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [filters, isHydrated]);
+
+  // Auto-expand more filters if any advanced filter is active
+  useEffect(() => {
+    if (filters.cardId || filters.ownerId || filters.categoryId) {
+      setShowMoreFilters(true);
+    }
+  }, [filters.cardId, filters.ownerId, filters.categoryId]);
 
   const key = filters.month ? `/api/transactions?month=${filters.month}` : null;
   const fallback =
@@ -116,6 +233,53 @@ export default function TransactionsView({
       transactions: txs.sort((a, b) => (a.transaction_date < b.transaction_date ? 1 : -1)),
     }));
   }, [filteredTransactions, cards]);
+
+  // Count active advanced filters
+  const activeAdvancedFilterCount = useMemo(() => {
+    let count = 0;
+    if (filters.cardId) count++;
+    if (filters.ownerId) count++;
+    if (filters.categoryId) count++;
+    return count;
+  }, [filters]);
+
+  // Get active filter details for chips
+  const activeFilters = useMemo(() => {
+    const active: { key: keyof FilterState; label: string; value: string }[] = [];
+
+    if (filters.cardId) {
+      const card = cards.find(c => c.id === filters.cardId);
+      active.push({ key: "cardId", label: "Card", value: card?.name ?? filters.cardId });
+    }
+    if (filters.ownerId) {
+      const owner = owners.find(o => o.id === filters.ownerId);
+      active.push({ key: "ownerId", label: "Owner", value: owner?.label ?? filters.ownerId });
+    }
+    if (filters.categoryId) {
+      const category = categories.find(c => c.id === filters.categoryId);
+      active.push({ key: "categoryId", label: "Category", value: category?.name ?? filters.categoryId });
+    }
+    if (filters.search) {
+      active.push({ key: "search", label: "Search", value: filters.search });
+    }
+
+    return active;
+  }, [filters, cards, owners, categories]);
+
+  function clearFilter(key: keyof FilterState) {
+    setFilters(prev => ({ ...prev, [key]: key === "search" ? "" : undefined }));
+  }
+
+  function clearAllFilters() {
+    setFilters(prev => ({
+      month: prev.month,
+      cardId: undefined,
+      ownerId: undefined,
+      categoryId: undefined,
+      search: "",
+    }));
+    setShowMoreFilters(false);
+  }
 
   async function updateTransaction(
     transaction: TransactionRecord,
@@ -168,7 +332,7 @@ export default function TransactionsView({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 md:space-y-6">
       <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div>
           <h1 className="text-2xl font-semibold text-slate-900">Transactions</h1>
@@ -178,94 +342,156 @@ export default function TransactionsView({
         </div>
       </header>
 
-      <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm grid-cols-1 sm:grid-cols-2 md:grid-cols-5">
-        <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
-          Month
-          <select
-            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
-            value={filters.month}
-            onChange={(event) =>
-              setFilters((prev) => ({ ...prev, month: event.target.value ?? "" }))
-            }
-          >
-            {months.map((month) => (
-              <option key={month} value={month}>
-                {format(new Date(`${month}-01`), "LLLL yyyy")}
-              </option>
+      {/* Filter Section */}
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        {/* Primary Filters - Always visible */}
+        <div className="p-4">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+            {/* Search */}
+            <div className="relative sm:col-span-2 md:col-span-1 md:order-first">
+              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+              <input
+                type="text"
+                className="w-full rounded-md border border-slate-300 pl-9 pr-3 py-2.5 text-sm text-slate-700 placeholder:text-slate-400 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                placeholder="Search merchant or note..."
+                value={filters.search ?? ""}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, search: event.target.value }))
+                }
+              />
+            </div>
+
+            {/* Month */}
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              Month
+              <select
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                value={filters.month}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, month: event.target.value ?? "" }))
+                }
+              >
+                {months.map((month) => (
+                  <option key={month} value={month}>
+                    {format(new Date(`${month}-01`), "LLLL yyyy")}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {/* More Filters Toggle */}
+            <div className="flex items-end">
+              <button
+                onClick={() => setShowMoreFilters(!showMoreFilters)}
+                className={`flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-colors min-h-[44px] w-full justify-center ${
+                  showMoreFilters || activeAdvancedFilterCount > 0
+                    ? "bg-slate-100 text-slate-900"
+                    : "bg-slate-50 text-slate-600 hover:bg-slate-100"
+                }`}
+              >
+                <FunnelIcon className="h-4 w-4" />
+                More Filters
+                {activeAdvancedFilterCount > 0 && (
+                  <span className="ml-1 rounded-full bg-slate-800 px-2 py-0.5 text-xs text-white">
+                    {activeAdvancedFilterCount}
+                  </span>
+                )}
+                <ChevronDownIcon className={`h-4 w-4 ml-auto transition-transform ${showMoreFilters ? "rotate-180" : ""}`} />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Advanced Filters - Expandable */}
+        {showMoreFilters && (
+          <div className="border-t border-slate-200 bg-slate-50 p-4">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-3">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+                Card
+                <select
+                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  value={filters.cardId ?? ""}
+                  onChange={(event) =>
+                    setFilters((prev) => ({
+                      ...prev,
+                      cardId: event.target.value || undefined,
+                    }))
+                  }
+                >
+                  <option value="">All Cards</option>
+                  {cards.map((card) => (
+                    <option key={card.id} value={card.id}>
+                      {card.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+                Owner
+                <select
+                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  value={filters.ownerId ?? ""}
+                  onChange={(event) =>
+                    setFilters((prev) => ({
+                      ...prev,
+                      ownerId: event.target.value || undefined,
+                    }))
+                  }
+                >
+                  <option value="">All Owners</option>
+                  {owners.map((owner) => (
+                    <option key={owner.id} value={owner.id}>
+                      {owner.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+                Category
+                <select
+                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  value={filters.categoryId ?? ""}
+                  onChange={(event) =>
+                    setFilters((prev) => ({
+                      ...prev,
+                      categoryId: event.target.value || undefined,
+                    }))
+                  }
+                >
+                  <option value="">All Categories</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+        )}
+
+        {/* Active Filter Chips */}
+        {activeFilters.length > 0 && (
+          <div className="border-t border-slate-200 px-4 py-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-slate-500 uppercase tracking-wide mr-1">
+              Active:
+            </span>
+            {activeFilters.map((filter) => (
+              <FilterChip
+                key={filter.key}
+                label={filter.label}
+                value={filter.value}
+                onRemove={() => clearFilter(filter.key)}
+              />
             ))}
-          </select>
-        </label>
-        <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
-          Card
-          <select
-            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
-            value={filters.cardId ?? ""}
-            onChange={(event) =>
-              setFilters((prev) => ({
-                ...prev,
-                cardId: event.target.value || undefined,
-              }))
-            }
-          >
-            <option value="">All</option>
-            {cards.map((card) => (
-              <option key={card.id} value={card.id}>
-                {card.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
-          Owner
-          <select
-            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
-            value={filters.ownerId ?? ""}
-            onChange={(event) =>
-              setFilters((prev) => ({
-                ...prev,
-                ownerId: event.target.value || undefined,
-              }))
-            }
-          >
-            <option value="">All</option>
-            {owners.map((owner) => (
-              <option key={owner.id} value={owner.id}>
-                {owner.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
-          Category
-          <select
-            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
-            value={filters.categoryId ?? ""}
-            onChange={(event) =>
-              setFilters((prev) => ({
-                ...prev,
-                categoryId: event.target.value || undefined,
-              }))
-            }
-          >
-            <option value="">All</option>
-            {categories.map((category) => (
-              <option key={category.id} value={category.id}>
-                {category.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 sm:col-span-2 md:col-span-1">
-          Search
-          <input
-            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
-            placeholder="Merchant or note"
-            value={filters.search ?? ""}
-            onChange={(event) =>
-              setFilters((prev) => ({ ...prev, search: event.target.value }))
-            }
-          />
-        </label>
+            <button
+              onClick={clearAllFilters}
+              className="ml-auto text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors px-2 py-1 min-h-[32px]"
+            >
+              Clear all
+            </button>
+          </div>
+        )}
       </div>
 
       {errorMessage && (
@@ -298,10 +524,10 @@ export default function TransactionsView({
           </div>
         )
       ) : (
-        <div className="space-y-6">
+        <div className="space-y-4 md:space-y-6">
           {groupedByCard.map(({ cardId, card, transactions: rows }) => (
-            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <header className="flex items-center justify-between border-b border-slate-100 pb-3">
+            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 bg-white p-3 md:p-4 shadow-sm">
+              <header className="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-100 pb-3 gap-2">
                 <div>
                   <h2 className="text-lg font-semibold text-slate-900">
                     {card?.name ?? cardId}
@@ -310,7 +536,7 @@ export default function TransactionsView({
                     {rows.length} transactions
                   </p>
                 </div>
-                <div className="text-right text-sm text-slate-600">
+                <div className="text-left sm:text-right text-sm text-slate-600">
                   <p>
                     Total spent:{" "}
                     <span className="font-medium">
@@ -341,14 +567,14 @@ export default function TransactionsView({
                     key={row.id}
                     className="rounded-lg border border-slate-100 bg-slate-50 p-4 space-y-3"
                   >
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <p className="font-medium text-slate-900">{row.merchant}</p>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium text-slate-900 truncate">{row.merchant}</p>
                         {row.description && (
-                          <p className="text-xs text-slate-500">{row.description}</p>
+                          <p className="text-xs text-slate-500 truncate">{row.description}</p>
                         )}
                       </div>
-                      <p className="font-semibold text-slate-900">
+                      <p className="font-semibold text-slate-900 whitespace-nowrap">
                         {formatMoney(row.amount, row.currency)}
                       </p>
                     </div>
@@ -365,7 +591,7 @@ export default function TransactionsView({
                         Owner
                         <select
                           value={row.owner_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-11"
+                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, { owner_id: event.target.value })
                           }
@@ -382,7 +608,7 @@ export default function TransactionsView({
                         Category
                         <select
                           value={row.category_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-11"
+                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, {
                               category_id: event.target.value,
@@ -404,7 +630,7 @@ export default function TransactionsView({
                     )}
                     <div className="flex justify-end pt-2 border-t border-slate-200">
                       <button
-                        className="min-h-11 min-w-11 px-4 py-2 text-sm font-semibold text-red-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        className="min-h-[44px] min-w-[44px] px-4 py-2 text-sm font-semibold text-red-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                         onClick={() => deleteTransactionRow(row)}
                         disabled={savingId === row.id}
                       >

--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -1,0 +1,52 @@
+interface IconProps {
+  className?: string;
+}
+
+export function ChartBarIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    </svg>
+  );
+}
+
+export function ListBulletIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+    </svg>
+  );
+}
+
+export function ArrowUpTrayIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+    </svg>
+  );
+}
+
+export function ClockIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+    </svg>
+  );
+}
+
+export function ArchiveBoxIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+    </svg>
+  );
+}
+
+export function TagIcon({ className }: IconProps) {
+  return (
+    <svg className={className || 'h-5 w-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- **Navigation Grouping (#60)**: Reorganized nav items into View, Import, and Settings groups with dropdown menus on desktop and grouped sections in mobile drawer
- **Filter UX (#61)**: Simplified transaction filters with expandable "More Filters" section, active filter chips, and localStorage persistence
- **Mobile Responsiveness (#62)**: Added sticky header, slide-in drawer navigation, 44px touch targets, and proper responsive layouts throughout

## Changes
- `app-shell.tsx`: New grouped navigation with dropdowns, mobile drawer with sections, icons for all nav items
- `transactions-view.tsx`: Simplified filters with expandable section, filter chips, localStorage persistence
- `dashboard-view.tsx`: Mobile touch target improvements
- `globals.css`: Added slide-in animation for mobile drawer
- `icons.tsx`: New icon components for navigation

## Test plan
- [ ] Verify navigation dropdown menus work on desktop
- [ ] Verify mobile drawer slides in and shows grouped sections
- [ ] Verify all touch targets are at least 44px
- [ ] Verify transaction filters collapse/expand properly
- [ ] Verify filter chips appear and can be removed
- [ ] Verify filter state persists in localStorage
- [ ] Run lint, type-check, and tests (all pass)

Closes #60
Closes #61
Closes #62

Generated with [Claude Code](https://claude.com/claude-code)