### PR TITLE
feat(import): show statement period in history

### DIFF
--- a/web/src/components/imports/import-history-view.tsx
+++ b/web/src/components/imports/import-history-view.tsx
@@ -35,6 +35,18 @@ function formatMoney(amount: number, currency: string) {
   }
 }
 
+function formatStatementPeriod(yearMonth: string): string {
+  // Parse YYYY-MM format and return "Month Year" (e.g., "December 2025")
+  const [year, month] = yearMonth.split("-");
+  if (!year || !month) return yearMonth;
+
+  const date = new Date(parseInt(year), parseInt(month) - 1, 1);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
 export default function ImportHistoryView({ initialHistory }: Props) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
@@ -142,7 +154,16 @@ export default function ImportHistoryView({ initialHistory }: Props) {
                 </div>
               </div>
 
-              <div className="grid gap-4 sm:grid-cols-3">
+              <div className="grid gap-4 sm:grid-cols-4">
+                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Statement Period</p>
+                  <p className="mt-2 text-lg font-semibold text-slate-900">
+                    {run.statement_month
+                      ? formatStatementPeriod(run.statement_month)
+                      : formatStatementPeriod(run.month)}
+                  </p>
+                  <p className="text-xs text-slate-500">Billing cycle</p>
+                </div>
                 <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
                   <p className="text-xs uppercase tracking-wide text-slate-500">Transactions</p>
                   <p className="mt-2 text-xl font-semibold text-slate-900">

--- a/web/src/db/repositories/import-runs.ts
+++ b/web/src/db/repositories/import-runs.ts
@@ -14,6 +14,7 @@ function toApiType(entity: ImportRunEntity): ImportRun {
     statement_file: entity.statementFile,
     card_id: entity.cardId,
     month: entity.month,
+    statement_month: entity.statementMonth ?? undefined,
     imported_at: entity.importedAt,
     status: entity.status,
     summary:
@@ -55,6 +56,7 @@ export async function appendImportHistory(
     statementFile: entry.statement_file,
     cardId: entry.card_id,
     month: entry.month,
+    statementMonth: entry.statement_month ?? null,
     importedAt: entry.imported_at,
     status: entry.status,
     summaryTransactions: entry.summary?.transactions ?? null,

--- a/web/src/db/schema.ts
+++ b/web/src/db/schema.ts
@@ -97,6 +97,7 @@ export const importRuns = sqliteTable("import_runs", {
     .notNull()
     .references(() => cards.id),
   month: text("month").notNull(),
+  statementMonth: text("statement_month"), // YYYY-MM format, extracted from statement
   importedAt: text("imported_at").notNull(),
   status: text("status", { enum: ["pending", "completed", "failed"] }).notNull(),
   // Summary stored as individual columns

--- a/web/src/lib/importer.ts
+++ b/web/src/lib/importer.ts
@@ -137,6 +137,7 @@ export async function commitExtraction(
       Array.from(commitMonths)[0] ??
       payload.transactions[0]?.transaction_date.slice(0, 7) ??
       "unknown",
+    statement_month: payload.metadata?.statement_month,
     imported_at: new Date().toISOString(),
     status: "completed",
     summary: payload.summary,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface ImportRun {
   statement_file: string;
   card_id: string;
   month: string;
+  statement_month?: string; // YYYY-MM format, extracted from statement
   imported_at: string;
   status: "pending" | "completed" | "failed";
   summary?: ImportRunSummary;


### PR DESCRIPTION
## Summary
- Add `statementMonth` column to import_runs table to store the billing period
- Extract statement_month from LLM metadata during import (from "Hesap Kesim Tarihi" or inferred)
- Display statement period in import history UI as "Month Year" format (e.g., "December 2025")
- Falls back to the existing `month` field if statement_month is not available

## Changes
- `web/src/db/schema.ts`: Added `statementMonth` column
- `web/src/db/repositories/import-runs.ts`: Updated repository to handle the new field
- `web/src/lib/types.ts`: Added `statement_month` to ImportRun interface
- `web/src/lib/importer.ts`: Pass statement_month from metadata to import history
- `web/src/components/imports/import-history-view.tsx`: Display statement period in 4-column grid

## Test plan
- [x] All existing tests pass (143/143)
- [ ] Import a new statement and verify statement period is extracted
- [ ] Check import history shows "Statement Period" column with formatted date
- [ ] Verify fallback works when statement_month is not available

Closes #69

Generated with [Claude Code](https://claude.com/claude-code)