### PR TITLE
fix(ui): add dark mode support to dashboard cards

### DIFF
--- a/web/src/components/dashboard/dashboard-empty.tsx
+++ b/web/src/components/dashboard/dashboard-empty.tsx
@@ -17,7 +17,7 @@ function StepIcon({ status }: { status: OnboardingStep["status"] }) {
   if (status === "completed") {
     // Checkmark
     return (
-      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
         </svg>
@@ -27,7 +27,7 @@ function StepIcon({ status }: { status: OnboardingStep["status"] }) {
   if (status === "current") {
     // Arrow
     return (
-      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
         </svg>
@@ -36,8 +36,8 @@ function StepIcon({ status }: { status: OnboardingStep["status"] }) {
   }
   // Upcoming - empty circle
   return (
-    <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-slate-300 text-slate-400">
-      <span className="h-2 w-2 rounded-full bg-slate-300" />
+    <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-slate-300 dark:border-slate-600 text-slate-400 dark:text-slate-500">
+      <span className="h-2 w-2 rounded-full bg-slate-300 dark:bg-slate-600" />
     </span>
   );
 }
@@ -48,25 +48,25 @@ function StepIcon({ status }: { status: OnboardingStep["status"] }) {
  */
 export default function DashboardEmpty() {
   return (
-    <div className="flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white p-8 shadow-sm text-center">
+    <div className="flex flex-col items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-8 shadow-sm text-center">
       {/* Icon */}
-      <div className="mb-4 text-slate-400">
+      <div className="mb-4 text-slate-400 dark:text-slate-500">
         <WalletIcon />
       </div>
 
       {/* Heading */}
-      <h2 className="text-xl font-semibold text-slate-900">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
         Welcome! Let&apos;s get started
       </h2>
-      <p className="mt-2 text-sm text-slate-500 max-w-md">
+      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400 max-w-md">
         Import your first credit card statement to unlock spending insights,
         transaction tracking, and personalized analytics.
       </p>
 
       {/* Onboarding Checklist */}
       <div className="mt-6 w-full max-w-sm">
-        <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-          <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 mb-3 text-left">
+        <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+          <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-3 text-left">
             Getting Started
           </h3>
           <ul className="space-y-3">
@@ -75,10 +75,10 @@ export default function DashboardEmpty() {
                 key={step.label}
                 className={`flex items-center gap-3 text-sm ${
                   step.status === "completed"
-                    ? "text-slate-500"
+                    ? "text-slate-500 dark:text-slate-400"
                     : step.status === "current"
-                    ? "text-blue-700 font-medium"
-                    : "text-slate-400"
+                    ? "text-blue-700 dark:text-blue-400 font-medium"
+                    : "text-slate-400 dark:text-slate-500"
                 }`}
               >
                 <StepIcon status={step.status} />
@@ -94,7 +94,7 @@ export default function DashboardEmpty() {
       {/* Primary CTA */}
       <Link
         href="/imports"
-        className="mt-6 inline-flex items-center justify-center gap-2 rounded-lg bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+        className="mt-6 inline-flex items-center justify-center gap-2 rounded-lg bg-slate-900 dark:bg-white px-6 py-3 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
       >
         <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path

--- a/web/src/components/dashboard/dashboard-view.tsx
+++ b/web/src/components/dashboard/dashboard-view.tsx
@@ -71,7 +71,7 @@ export default function DashboardView({ summary, months }: Props) {
 
   if (error) {
     return (
-      <div className="rounded-xl bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+      <div className="rounded-xl bg-red-50 dark:bg-red-900/20 p-6 text-sm text-red-700 dark:text-red-400 shadow-sm">
         Failed to load dashboard: {error.message}
       </div>
     );
@@ -84,12 +84,12 @@ export default function DashboardView({ summary, months }: Props) {
         {/* Header skeleton */}
         <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
           <div>
-            <div className="h-8 w-48 animate-pulse rounded-md bg-slate-200" />
-            <div className="mt-2 h-4 w-32 animate-pulse rounded-md bg-slate-200" />
+            <div className="h-8 w-48 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+            <div className="mt-2 h-4 w-32 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
           </div>
           <div className="flex items-center gap-2">
             <Spinner size="sm" />
-            <div className="h-10 w-48 animate-pulse rounded-xl bg-slate-200" />
+            <div className="h-10 w-48 animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700" />
           </div>
         </div>
         <SkeletonHeroMetrics />
@@ -111,13 +111,13 @@ export default function DashboardView({ summary, months }: Props) {
       {/* Header with month selector */}
       <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+          <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-3xl">
             {new Date(`${activeSummary.month}-01`).toLocaleDateString("tr-TR", {
               year: "numeric",
               month: "long",
             })}
           </h1>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             Your monthly spending overview
           </p>
         </div>
@@ -128,7 +128,7 @@ export default function DashboardView({ summary, months }: Props) {
           <select
             value={selectedMonth}
             onChange={(event) => setSelectedMonth(event.target.value)}
-            className="rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] w-full sm:w-48"
+            className="rounded-xl border-0 bg-white dark:bg-slate-800 px-4 py-2.5 text-sm font-medium text-slate-700 dark:text-slate-300 shadow-sm ring-1 ring-slate-200 dark:ring-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] w-full sm:w-48"
           >
             {months.map((monthOption) => (
               <option key={monthOption} value={monthOption}>

--- a/web/src/components/dashboard/hero-metrics.tsx
+++ b/web/src/components/dashboard/hero-metrics.tsx
@@ -28,27 +28,27 @@ export default function HeroMetrics({ totalSpent, currency, vsLastMonth }: HeroM
 
   return (
     <div className="grid gap-6 sm:grid-cols-2">
-      <div className="rounded-xl bg-white p-8 shadow-sm">
-        <p className="text-sm font-medium text-slate-500">Total Spent</p>
-        <p className="mt-3 text-4xl font-bold tracking-tight text-slate-900">
+      <div className="rounded-xl bg-white dark:bg-slate-800 p-8 shadow-sm">
+        <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Total Spent</p>
+        <p className="mt-3 text-4xl font-bold tracking-tight text-slate-900 dark:text-white">
           {formatMoney(totalSpent, currency)}
         </p>
       </div>
 
-      <div className="rounded-xl bg-white p-8 shadow-sm">
-        <p className="text-sm font-medium text-slate-500">vs Last Month</p>
+      <div className="rounded-xl bg-white dark:bg-slate-800 p-8 shadow-sm">
+        <p className="text-sm font-medium text-slate-500 dark:text-slate-400">vs Last Month</p>
         {vsLastMonth ? (
           <div className="mt-3">
             <p className={`text-4xl font-bold tracking-tight ${changeColor}`}>
               {changeIcon}{vsLastMonth.pctChange.toFixed(1)}%
             </p>
-            <p className="mt-2 text-sm text-slate-500">
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
               {isIncrease ? "Spent more" : "Saved"}{" "}
               {formatMoney(Math.abs(vsLastMonth.change), currency)}
             </p>
           </div>
         ) : (
-          <p className="mt-3 text-lg text-slate-400">No previous data</p>
+          <p className="mt-3 text-lg text-slate-400 dark:text-slate-500">No previous data</p>
         )}
       </div>
     </div>

--- a/web/src/components/dashboard/recent-transactions.tsx
+++ b/web/src/components/dashboard/recent-transactions.tsx
@@ -46,22 +46,22 @@ export default function RecentTransactions({
 
   if (recentTransactions.length === 0) {
     return (
-      <div className="rounded-xl bg-white p-6 shadow-sm">
+      <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-900">Recent Transactions</h2>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Recent Transactions</h2>
         </div>
-        <p className="mt-4 text-sm text-slate-500">No transactions available yet.</p>
+        <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">No transactions available yet.</p>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl bg-white p-6 shadow-sm">
+    <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-slate-900">Recent Transactions</h2>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Recent Transactions</h2>
         <Link
           href="/transactions"
-          className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          className="text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
         >
           View all
         </Link>
@@ -85,10 +85,10 @@ export default function RecentTransactions({
                   />
                 </div>
                 <div className="min-w-0">
-                  <p className="truncate font-medium text-slate-900">{tx.merchant}</p>
-                  <div className="flex items-center gap-2 text-xs text-slate-500">
+                  <p className="truncate font-medium text-slate-900 dark:text-white">{tx.merchant}</p>
+                  <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
                     <span>{formatDate(tx.transaction_date)}</span>
-                    <span className="text-slate-300">|</span>
+                    <span className="text-slate-300 dark:text-slate-600">|</span>
                     <span
                       className="rounded-md px-1.5 py-0.5 text-xs"
                       style={{
@@ -103,7 +103,7 @@ export default function RecentTransactions({
               </div>
               <p
                 className={`flex-shrink-0 font-medium ${
-                  isExpense ? "text-slate-900" : "text-emerald-600"
+                  isExpense ? "text-slate-900 dark:text-white" : "text-emerald-600 dark:text-emerald-400"
                 }`}
               >
                 {isExpense ? "-" : "+"}

--- a/web/src/components/dashboard/spending-trend-chart.tsx
+++ b/web/src/components/dashboard/spending-trend-chart.tsx
@@ -50,16 +50,16 @@ export default function SpendingTrendChart({ data, currency }: SpendingTrendChar
 
   if (chartData.length === 0) {
     return (
-      <div className="rounded-xl bg-white p-6 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-900">Spending Trend</h2>
-        <p className="mt-4 text-sm text-slate-500">No trend data available yet.</p>
+      <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Spending Trend</h2>
+        <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">No trend data available yet.</p>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl bg-white p-6 shadow-sm">
-      <h2 className="text-lg font-semibold text-slate-900">Spending Trend</h2>
+    <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Spending Trend</h2>
       <div className="mt-6 h-64">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData}>

--- a/web/src/components/dashboard/top-categories.tsx
+++ b/web/src/components/dashboard/top-categories.tsx
@@ -36,22 +36,22 @@ export default function TopCategories({ categories, currency }: TopCategoriesPro
 
   if (topCategories.length === 0) {
     return (
-      <div className="rounded-xl bg-white p-6 shadow-sm">
+      <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-900">Top Categories</h2>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Top Categories</h2>
         </div>
-        <p className="mt-4 text-sm text-slate-500">No category data available yet.</p>
+        <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">No category data available yet.</p>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl bg-white p-6 shadow-sm">
+    <div className="rounded-xl bg-white dark:bg-slate-800 p-6 shadow-sm">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-slate-900">Top Categories</h2>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Top Categories</h2>
         <Link
           href="/categories"
-          className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          className="text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
         >
           See all
         </Link>
@@ -67,16 +67,16 @@ export default function TopCategories({ categories, currency }: TopCategoriesPro
                     className="h-3 w-3 rounded-full"
                     style={{ backgroundColor: color }}
                   />
-                  <span className="font-medium text-slate-700">{category.label}</span>
+                  <span className="font-medium text-slate-700 dark:text-slate-300">{category.label}</span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-slate-500">{category.percentage.toFixed(0)}%</span>
-                  <span className="font-medium text-slate-900">
+                  <span className="text-slate-500 dark:text-slate-400">{category.percentage.toFixed(0)}%</span>
+                  <span className="font-medium text-slate-900 dark:text-white">
                     {formatMoney(category.total, currency)}
                   </span>
                 </div>
               </div>
-              <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-100">
+              <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
                 <div
                   className="h-full rounded-full transition-all duration-300"
                   style={{

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -11,7 +11,7 @@ function SkeletonBase({ className }: SkeletonBaseProps) {
   return (
     <div
       className={cn(
-        "animate-pulse rounded-md bg-slate-200",
+        "animate-pulse rounded-md bg-slate-200 dark:bg-slate-700",
         className
       )}
       aria-hidden="true"
@@ -27,7 +27,7 @@ export function SkeletonCard({ className }: SkeletonBaseProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+        "rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm",
         className
       )}
       aria-hidden="true"
@@ -47,7 +47,7 @@ export function SkeletonChart({ className }: SkeletonBaseProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+        "rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm",
         className
       )}
       aria-hidden="true"
@@ -147,7 +147,7 @@ export function SkeletonCategoryList({ className, count = 5 }: SkeletonBaseProps
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-3",
+        "rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm space-y-3",
         className
       )}
       aria-hidden="true"
@@ -171,13 +171,13 @@ export function SkeletonTransactionCard({ className, rowCount = 5 }: SkeletonBas
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm",
+        "rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm",
         className
       )}
       aria-hidden="true"
     >
       {/* Card header */}
-      <div className="flex items-center justify-between border-b border-slate-100 pb-3 mb-3">
+      <div className="flex items-center justify-between border-b border-slate-100 dark:border-slate-700 pb-3 mb-3">
         <div>
           <SkeletonBase className="h-5 w-32 mb-1" />
           <SkeletonBase className="h-3 w-20" />
@@ -204,7 +204,7 @@ export function SkeletonImportCard({ className }: SkeletonBaseProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-4",
+        "rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm space-y-4",
         className
       )}
       aria-hidden="true"
@@ -223,7 +223,7 @@ export function SkeletonImportCard({ className }: SkeletonBaseProps) {
       {/* Stats grid */}
       <div className="grid gap-4 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-lg border border-slate-100 bg-slate-50 p-4">
+          <div key={i} className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
             <SkeletonBase className="h-3 w-20 mb-2" />
             <SkeletonBase className="h-6 w-16" />
             <SkeletonBase className="h-3 w-12 mt-1" />


### PR DESCRIPTION
## Summary
- Add `dark:` Tailwind variants to all dashboard card components
- Update hero-metrics, spending-trend-chart, top-categories, recent-transactions
- Update skeleton and empty state components for dark mode consistency
- Fix dashboard-view header, select dropdown, and error states

## Test plan
- [ ] Toggle to dark mode and verify all dashboard cards have dark backgrounds
- [ ] Check that text colors are readable in both modes
- [ ] Verify skeleton loading states render correctly in dark mode
- [ ] Test empty state (no data) appears correctly in dark mode

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)