### PR TITLE
fix(ui): add dark mode support to all pages

### DIFF
--- a/web/src/components/categories/categories-manager.tsx
+++ b/web/src/components/categories/categories-manager.tsx
@@ -72,8 +72,8 @@ function ColorPalette({
           className={cn(
             "h-7 w-7 rounded-md border-2 transition-all",
             value === color.value
-              ? "border-slate-900 scale-110 shadow-md"
-              : "border-transparent hover:scale-105 hover:border-slate-300"
+              ? "border-slate-900 dark:border-white scale-110 shadow-md"
+              : "border-transparent hover:scale-105 hover:border-slate-300 dark:hover:border-slate-500"
           )}
           style={{ backgroundColor: color.value }}
         />
@@ -219,27 +219,27 @@ export default function CategoriesManager({ initialCategories }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Categories</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Categories</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           Manage spending categories used for dashboards and transactions.
         </p>
       </header>
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-600 dark:text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+        <div className="rounded-md border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-4 text-sm text-emerald-700 dark:text-emerald-400">
           {success}
         </div>
       )}
 
       {/* Quick Add Presets */}
       {availablePresets.length > 0 && (
-        <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-          <p className="text-sm font-medium text-slate-700 mb-3">Quick add common categories</p>
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm">
+          <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">Quick add common categories</p>
           <div className="flex flex-wrap gap-2">
             {availablePresets.map((preset) => (
               <button
@@ -247,7 +247,7 @@ export default function CategoriesManager({ initialCategories }: Props) {
                 type="button"
                 onClick={() => quickAddCategory(preset)}
                 disabled={savingId === `preset-${preset.name}`}
-                className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100 hover:border-slate-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 rounded-full border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-3 py-1.5 text-sm font-medium text-slate-700 dark:text-slate-300 transition hover:bg-slate-100 dark:hover:bg-slate-600 hover:border-slate-300 dark:hover:border-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ColorChip color={preset.color} />
                 {savingId === `preset-${preset.name}` ? "Adding..." : preset.name}
@@ -260,21 +260,21 @@ export default function CategoriesManager({ initialCategories }: Props) {
       {/* Create Custom Category Form */}
       <form
         onSubmit={createCategory}
-        className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm space-y-4"
+        className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm space-y-4"
       >
-        <p className="text-sm font-medium text-slate-700">Create custom category</p>
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Create custom category</p>
 
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
-          <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+          <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Name
             <input
-              className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11 w-full"
+              className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-11 w-full"
               placeholder="e.g. Subscriptions"
               value={newName}
               onChange={(event) => setNewName(event.target.value)}
             />
           </label>
-          <div className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+          <div className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Color
             <div className="mt-1 flex items-center gap-3">
               <ColorChip color={newColor} className="h-8 w-8 rounded-md" />
@@ -291,7 +291,7 @@ export default function CategoriesManager({ initialCategories }: Props) {
           <button
             type="submit"
             disabled={savingId === "new"}
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400 min-h-11"
+            className="rounded-md bg-slate-900 dark:bg-white px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-400 min-h-11"
           >
             {savingId === "new" ? "Adding..." : "Add category"}
           </button>
@@ -299,8 +299,8 @@ export default function CategoriesManager({ initialCategories }: Props) {
       </form>
 
       {/* Existing Categories List */}
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        <p className="text-sm font-medium text-slate-700 mb-4">
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm">
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-4">
           Your categories ({categories.length})
         </p>
 
@@ -341,16 +341,16 @@ export default function CategoriesManager({ initialCategories }: Props) {
 
             {/* Desktop table view */}
             <div className="hidden md:block overflow-x-auto">
-              <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                 <thead>
-                  <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                  <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     <th className="px-3 py-2">Color</th>
                     <th className="px-3 py-2">Name</th>
                     <th className="px-3 py-2">ID</th>
                     <th className="px-3 py-2 text-right">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-100 text-slate-700">
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                   {categories.map((category) => (
                     <CategoryRow
                       key={category.id}
@@ -393,23 +393,23 @@ function MobileCategoryCard({ category, onSave, onDelete, isBusy }: RowProps) {
   }
 
   return (
-    <div className="rounded-lg border border-slate-100 bg-slate-50 p-4 space-y-3">
+    <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4 space-y-3">
       <div className="flex items-center gap-3">
         <ColorChip color={color} className="h-10 w-10 rounded-md flex-shrink-0" />
         <input
-          className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-11"
+          className="flex-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-11"
           value={name}
           onChange={(event) => handleNameChange(event.target.value)}
         />
       </div>
       <ColorPalette value={color} onChange={handleColorChange} />
-      <p className="font-mono text-xs text-slate-500 truncate">ID: {category.id}</p>
+      <p className="font-mono text-xs text-slate-500 dark:text-slate-400 truncate">ID: {category.id}</p>
       <div className="flex gap-2">
         <button
           type="button"
           onClick={() => onSave(category.id, { name, color })}
           disabled={isBusy || !dirty}
-          className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+          className="flex-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 shadow-sm transition hover:bg-slate-100 dark:hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
         >
           {isBusy ? "Saving..." : "Save"}
         </button>
@@ -417,7 +417,7 @@ function MobileCategoryCard({ category, onSave, onDelete, isBusy }: RowProps) {
           type="button"
           onClick={() => onDelete(category.id)}
           disabled={isBusy}
-          className="flex-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-600 shadow-sm transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+          className="flex-1 rounded-md border border-red-300 dark:border-red-700 px-3 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm transition hover:bg-red-50 dark:hover:bg-red-900/20 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
         >
           {isBusy ? "Deleting..." : "Delete"}
         </button>
@@ -444,17 +444,17 @@ function CategoryRow({ category, onSave, onDelete, isBusy }: RowProps) {
   }
 
   return (
-    <tr>
+    <tr className="hover:bg-slate-50 dark:hover:bg-slate-700/50">
       <td className="px-3 py-2">
         <div className="relative">
           <button
             type="button"
             onClick={() => setShowPalette(!showPalette)}
-            className="h-8 w-12 rounded border border-slate-300 hover:border-slate-400 transition"
+            className="h-8 w-12 rounded border border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition"
             style={{ backgroundColor: color }}
           />
           {showPalette && (
-            <div className="absolute left-0 top-full mt-1 z-10 bg-white rounded-lg shadow-lg border border-slate-200 p-2">
+            <div className="absolute left-0 top-full mt-1 z-10 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 p-2">
               <ColorPalette value={color} onChange={handleColorChange} />
             </div>
           )}
@@ -462,19 +462,19 @@ function CategoryRow({ category, onSave, onDelete, isBusy }: RowProps) {
       </td>
       <td className="px-3 py-2">
         <input
-          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700"
+          className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white"
           value={name}
           onChange={(event) => handleNameChange(event.target.value)}
         />
       </td>
-      <td className="px-3 py-2 font-mono text-xs text-slate-500">{category.id}</td>
+      <td className="px-3 py-2 font-mono text-xs text-slate-500 dark:text-slate-400">{category.id}</td>
       <td className="px-3 py-2 text-right">
         <div className="flex justify-end gap-2">
           <button
             type="button"
             onClick={() => onSave(category.id, { name, color })}
             disabled={isBusy || !dirty}
-            className="rounded-md border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md border border-slate-300 dark:border-slate-600 px-3 py-1 text-xs font-semibold text-slate-700 dark:text-slate-300 shadow-sm transition hover:bg-slate-100 dark:hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isBusy ? "Saving..." : "Save"}
           </button>
@@ -482,7 +482,7 @@ function CategoryRow({ category, onSave, onDelete, isBusy }: RowProps) {
             type="button"
             onClick={() => onDelete(category.id)}
             disabled={isBusy}
-            className="rounded-md border border-red-300 px-3 py-1 text-xs font-semibold text-red-600 shadow-sm transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md border border-red-300 dark:border-red-700 px-3 py-1 text-xs font-semibold text-red-600 dark:text-red-400 shadow-sm transition hover:bg-red-50 dark:hover:bg-red-900/20 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isBusy ? "Deleting..." : "Delete"}
           </button>

--- a/web/src/components/imports/imports-view.tsx
+++ b/web/src/components/imports/imports-view.tsx
@@ -137,8 +137,8 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Statement import</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Statement import</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           Upload a PDF statement and we will automatically extract transactions, match your card and owner.
         </p>
       </header>
@@ -154,11 +154,11 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
 
       {/* Step 2: Extract & Preview button */}
       {statementPdfBase64 && !showPreview && (
-        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-slate-700">Ready to extract</p>
-              <p className="text-xs text-slate-500 mt-1">
+              <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Ready to extract</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                 {fileName} - Uses Claude AI to extract transactions
               </p>
             </div>
@@ -166,7 +166,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
               type="button"
               onClick={handleExtractPreview}
               disabled={isExtracting}
-              className="rounded-md bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              className="rounded-md bg-slate-900 dark:bg-white px-5 py-2.5 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-400 dark:disabled:bg-slate-600"
             >
               {isExtracting ? (
                 <span className="flex items-center gap-2">
@@ -183,32 +183,32 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
 
       {/* Step 3: Show extracted preview with edit capability */}
       {showPreview && extractedMetadata && (
-        <div className="space-y-4 rounded-xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
           <div>
-            <p className="text-base font-semibold text-emerald-800">Extraction complete</p>
-            <p className="text-sm text-emerald-600">Review and confirm the extracted information</p>
+            <p className="text-base font-semibold text-emerald-800 dark:text-emerald-400">Extraction complete</p>
+            <p className="text-sm text-emerald-600 dark:text-emerald-500">Review and confirm the extracted information</p>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Month
               <input
                 type="month"
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-white bg-white dark:bg-slate-700"
                 value={month}
                 onChange={(event) => setMonth(event.target.value)}
               />
               {extractedMetadata.statement_month && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Detected: {extractedMetadata.statement_month}
                 </span>
               )}
             </label>
 
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Card
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-white bg-white dark:bg-slate-700"
                 value={cardId}
                 onChange={(event) => setCardId(event.target.value)}
               >
@@ -219,16 +219,16 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 ))}
               </select>
               {extractedMetadata.card_last4 && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Matched: ****{extractedMetadata.card_last4}
                 </span>
               )}
             </label>
 
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Owner
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-white bg-white dark:bg-slate-700"
                 value={ownerId}
                 onChange={(event) => setOwnerId(event.target.value)}
               >
@@ -239,7 +239,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 ))}
               </select>
               {extractedMetadata.cardholder_name && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Matched: {extractedMetadata.cardholder_name}
                 </span>
               )}
@@ -250,7 +250,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
             <button
               type="button"
               onClick={handleConfirmImport}
-              className="rounded-md bg-emerald-700 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600"
+              className="rounded-md bg-emerald-700 dark:bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600 dark:hover:bg-emerald-500"
             >
               Confirm Import
             </button>
@@ -260,7 +260,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 setShowPreview(false);
                 setExtractedMetadata(null);
               }}
-              className="rounded-md bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50"
+              className="rounded-md bg-white dark:bg-slate-700 px-5 py-2.5 text-sm font-semibold text-slate-700 dark:text-slate-300 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-600 transition hover:bg-slate-50 dark:hover:bg-slate-600"
             >
               Cancel
             </button>
@@ -269,23 +269,23 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
       )}
 
       {error && (
-        <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
-          <ErrorIcon className="h-5 w-5 flex-shrink-0 text-red-500 mt-0.5" />
+        <div className="flex items-start gap-3 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4">
+          <ErrorIcon className="h-5 w-5 flex-shrink-0 text-red-500 dark:text-red-400 mt-0.5" />
           <div>
-            <p className="text-sm font-medium text-red-800">Import failed</p>
-            <p className="text-sm text-red-600 mt-1">{error}</p>
+            <p className="text-sm font-medium text-red-800 dark:text-red-400">Import failed</p>
+            <p className="text-sm text-red-600 dark:text-red-500 mt-1">{error}</p>
           </div>
         </div>
       )}
 
       {response && !showPreview && (
-        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm">
+        <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
           <div className="flex items-start gap-3">
-            <SuccessIcon className="h-6 w-6 flex-shrink-0 text-emerald-500 mt-0.5" />
+            <SuccessIcon className="h-6 w-6 flex-shrink-0 text-emerald-500 dark:text-emerald-400 mt-0.5" />
             <div>
-              <p className="text-base font-semibold text-emerald-800">Import queued</p>
-              <p className="mt-1 text-sm text-emerald-700">
-                <span className="font-mono text-xs bg-emerald-100 px-1.5 py-0.5 rounded">{response.runId}</span>
+              <p className="text-base font-semibold text-emerald-800 dark:text-emerald-400">Import queued</p>
+              <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-500">
+                <span className="font-mono text-xs bg-emerald-100 dark:bg-emerald-800 px-1.5 py-0.5 rounded">{response.runId}</span>
                 {" "}&bull;{" "}
                 {response.summary.transactions} transactions
                 {" "}&bull;{" "}
@@ -295,13 +295,13 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 })}
               </p>
               {response.warnings.length > 0 && (
-                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-emerald-800">
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-emerald-800 dark:text-emerald-400">
                   {response.warnings.map((warning) => (
                     <li key={warning}>{warning}</li>
                   ))}
                 </ul>
               )}
-              <p className="mt-3 text-xs text-emerald-600">
+              <p className="mt-3 text-xs text-emerald-600 dark:text-emerald-500">
                 {response.autoCommitted
                   ? "Transactions were written to the ledger automatically."
                   : "Review the pending import to approve and commit."}

--- a/web/src/components/imports/pending-imports-view.tsx
+++ b/web/src/components/imports/pending-imports-view.tsx
@@ -129,19 +129,19 @@ export default function PendingImportsView({ initialRuns }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Pending imports</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Pending imports</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           Review staged LLM extractions and approve them to merge into your ledger.
         </p>
       </header>
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-600 dark:text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+        <div className="rounded-md border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-4 text-sm text-emerald-700 dark:text-emerald-400">
           {success}
         </div>
       )}
@@ -166,51 +166,51 @@ export default function PendingImportsView({ initialRuns }: Props) {
             {runs.map((run) => (
               <div
                 key={run.run_id}
-                className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+                className="space-y-4 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm"
               >
               <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
                 <div>
-                  <p className="text-sm font-medium text-slate-500">Run ID</p>
-                  <p className="font-mono text-slate-900">{run.run_id}</p>
+                  <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Run ID</p>
+                  <p className="font-mono text-slate-900 dark:text-white">{run.run_id}</p>
                 </div>
-                <div className="text-sm text-slate-500">
+                <div className="text-sm text-slate-500 dark:text-slate-400">
                   <p>
                     Saved on {format(new Date(run.saved_at), "PPpp")}
                   </p>
                   <p>
-                    Statement: <span className="font-medium text-slate-900">{run.statement_file}</span>
+                    Statement: <span className="font-medium text-slate-900 dark:text-white">{run.statement_file}</span>
                   </p>
                 </div>
               </div>
 
               <div className="grid gap-4 sm:grid-cols-3">
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Transactions</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Transactions</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {run.summary.transactions}
                   </p>
                   {run.month && (
-                    <p className="text-xs text-slate-500">{run.month}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{run.month}</p>
                   )}
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Estimated spend</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Estimated spend</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {formatMoney(run.summary.total_spend, run.summary.currency)}
                   </p>
-                  <p className="text-xs text-slate-500">Net of refunds</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Net of refunds</p>
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Card / Owner</p>
-                  <p className="mt-2 text-sm font-medium text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Card / Owner</p>
+                  <p className="mt-2 text-sm font-medium text-slate-900 dark:text-white">
                     {run.card_id ?? "Unknown card"}
                   </p>
-                  <p className="text-xs text-slate-500">{run.owner_id ?? "Unassigned"}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{run.owner_id ?? "Unassigned"}</p>
                 </div>
               </div>
 
               {run.warnings.length > 0 && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+                <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4 text-sm text-amber-700 dark:text-amber-400">
                   <p className="font-medium">Warnings</p>
                   <ul className="list-disc space-y-1 pl-5">
                     {run.warnings.map((warning) => (
@@ -221,11 +221,11 @@ export default function PendingImportsView({ initialRuns }: Props) {
               )}
 
               <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                   Sample transactions
                 </p>
               {run.sample_transactions.length === 0 ? (
-                <p className="mt-2 text-sm text-slate-500">
+                <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                   No transactions extracted in this run.
                 </p>
               ) : (
@@ -235,18 +235,18 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     {run.sample_transactions.map((tx) => (
                       <div
                         key={tx.id}
-                        className="rounded-lg border border-slate-100 bg-slate-50 p-3"
+                        className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-3"
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <p className="font-medium text-slate-900 truncate">{tx.merchant}</p>
-                            <p className="text-xs text-slate-500">{tx.card_id}</p>
+                            <p className="font-medium text-slate-900 dark:text-white truncate">{tx.merchant}</p>
+                            <p className="text-xs text-slate-500 dark:text-slate-400">{tx.card_id}</p>
                           </div>
-                          <p className="font-semibold text-slate-900 flex-shrink-0">
+                          <p className="font-semibold text-slate-900 dark:text-white flex-shrink-0">
                             {formatMoney(tx.amount, run.summary.currency)}
                           </p>
                         </div>
-                        <p className="mt-1 text-xs text-slate-500">
+                        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                           {format(new Date(tx.transaction_date), "dd MMM yyyy")}
                         </p>
                       </div>
@@ -255,16 +255,16 @@ export default function PendingImportsView({ initialRuns }: Props) {
 
                   {/* Desktop table view for sample transactions */}
                   <div className="mt-3 hidden md:block overflow-x-auto">
-                    <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                       <thead>
-                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                           <th className="px-3 py-2">Date</th>
                           <th className="px-3 py-2">Merchant</th>
                           <th className="px-3 py-2">Card</th>
                           <th className="px-3 py-2 text-right">Amount</th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-slate-100 text-slate-700">
+                      <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                         {run.sample_transactions.map((tx) => (
                           <tr key={tx.id}>
                             <td className="whitespace-nowrap px-3 py-2">
@@ -272,7 +272,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                             </td>
                             <td className="px-3 py-2">{tx.merchant}</td>
                             <td className="px-3 py-2">{tx.card_id}</td>
-                            <td className="whitespace-nowrap px-3 py-2 text-right font-medium">
+                            <td className="whitespace-nowrap px-3 py-2 text-right font-medium text-slate-900 dark:text-white">
                               {formatMoney(tx.amount, run.summary.currency)}
                             </td>
                           </tr>
@@ -283,7 +283,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                 </>
               )}
               {run.sample_count < run.total_transactions && (
-                <p className="mt-2 text-xs text-slate-500">
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
                   Showing first {run.sample_count} of {run.total_transactions} transactions.
                   {run.months.length > 1 && (
                     <span className="ml-1">
@@ -295,8 +295,8 @@ export default function PendingImportsView({ initialRuns }: Props) {
               </div>
 
               {expandedRun === run.run_id && details[run.run_id] && (
-                <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     All transactions ({details[run.run_id].transactions.length})
                   </p>
 
@@ -305,26 +305,26 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     {details[run.run_id].transactions.map((tx) => (
                       <div
                         key={tx.id}
-                        className="rounded-lg border border-slate-200 bg-white p-3 space-y-2"
+                        className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 p-3 space-y-2"
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <p className="font-medium text-slate-900 truncate">{tx.merchant}</p>
+                            <p className="font-medium text-slate-900 dark:text-white truncate">{tx.merchant}</p>
                             {tx.description && (
-                              <p className="text-xs text-slate-500 truncate">{tx.description}</p>
+                              <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{tx.description}</p>
                             )}
                           </div>
-                          <p className="font-semibold text-slate-900 flex-shrink-0">
+                          <p className="font-semibold text-slate-900 dark:text-white flex-shrink-0">
                             {formatMoney(tx.amount, run.summary.currency)}
                           </p>
                         </div>
-                        <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+                        <div className="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
                           <span>{format(new Date(tx.transaction_date), "dd MMM yyyy")}</span>
                           <span>Card: {tx.card_id}</span>
                           {tx.owner_id && <span>Owner: {tx.owner_id}</span>}
                         </div>
                         {tx.original_currency && (
-                          <p className="text-xs text-slate-500">
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
                             Original: {tx.original_currency} {Math.abs(tx.original_amount ?? 0).toFixed(2)}
                           </p>
                         )}
@@ -334,9 +334,9 @@ export default function PendingImportsView({ initialRuns }: Props) {
 
                   {/* Desktop table view for all transactions */}
                   <div className="mt-3 hidden md:block overflow-x-auto">
-                    <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-600 text-sm">
                       <thead>
-                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                           <th className="px-3 py-2">Date</th>
                           <th className="px-3 py-2">Merchant</th>
                           <th className="px-3 py-2">Description</th>
@@ -346,24 +346,24 @@ export default function PendingImportsView({ initialRuns }: Props) {
                           <th className="px-3 py-2 text-right">Amount</th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-slate-100 text-slate-700">
+                      <tbody className="divide-y divide-slate-100 dark:divide-slate-600 text-slate-700 dark:text-slate-300">
                         {details[run.run_id].transactions.map((tx) => (
                           <tr key={tx.id}>
                             <td className="whitespace-nowrap px-3 py-2">
                               {format(new Date(tx.transaction_date), "dd MMM yyyy")}
                             </td>
                             <td className="px-3 py-2">{tx.merchant}</td>
-                            <td className="px-3 py-2 text-xs text-slate-500">
+                            <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400">
                               {tx.description ?? "-"}
                             </td>
                             <td className="px-3 py-2">{tx.card_id}</td>
                             <td className="px-3 py-2">{tx.owner_id ?? "-"}</td>
-                            <td className="whitespace-nowrap px-3 py-2 text-right text-xs text-slate-500">
+                            <td className="whitespace-nowrap px-3 py-2 text-right text-xs text-slate-500 dark:text-slate-400">
                               {tx.original_currency
                                 ? `${tx.original_currency} ${Math.abs(tx.original_amount ?? 0).toFixed(2)}`
                                 : "-"}
                             </td>
-                            <td className="whitespace-nowrap px-3 py-2 text-right font-medium">
+                            <td className="whitespace-nowrap px-3 py-2 text-right font-medium text-slate-900 dark:text-white">
                               {formatMoney(tx.amount, run.summary.currency)}
                             </td>
                           </tr>
@@ -372,7 +372,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     </table>
                   </div>
                   {details[run.run_id].statement_notes && (
-                    <p className="mt-3 text-xs text-slate-500">
+                    <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
                       Notes: {details[run.run_id].statement_notes}
                     </p>
                   )}
@@ -384,7 +384,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   <button
                     type="button"
                     onClick={() => toggleDetails(run.run_id)}
-                    className="rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 min-h-11 w-full md:w-auto"
+                    className="rounded-md border border-slate-300 dark:border-slate-600 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 shadow-sm transition hover:bg-slate-100 dark:hover:bg-slate-700 min-h-11 w-full md:w-auto"
                   >
                     {expandedRun === run.run_id
                       ? "Hide transactions"
@@ -397,7 +397,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   type="button"
                   onClick={() => approve(run.run_id)}
                   disabled={approvingId === run.run_id}
-                  className="rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400 min-h-11 w-full md:w-auto"
+                  className="rounded-md bg-slate-900 dark:bg-white px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-400 dark:disabled:bg-slate-600 min-h-11 w-full md:w-auto"
                 >
                   {approvingId === run.run_id ? "Approving..." : "Approve & commit"}
                 </button>
@@ -405,7 +405,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   type="button"
                   onClick={() => remove(run.run_id)}
                   disabled={deletingId === run.run_id}
-                  className="rounded-md border border-red-300 px-4 py-2 text-sm font-semibold text-red-600 shadow-sm transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 min-h-11 w-full md:w-auto"
+                  className="rounded-md border border-red-300 dark:border-red-700 px-4 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm transition hover:bg-red-50 dark:hover:bg-red-900/20 disabled:cursor-not-allowed disabled:opacity-50 min-h-11 w-full md:w-auto"
                 >
                   {deletingId === run.run_id ? "Removing..." : "Discard"}
                 </button>

--- a/web/src/components/settings/settings-view.tsx
+++ b/web/src/components/settings/settings-view.tsx
@@ -117,20 +117,20 @@ export function SettingsView({ user }: SettingsViewProps) {
   return (
     <div className="space-y-8">
       <div className="flex items-center gap-3">
-        <CogIcon className="h-8 w-8 text-slate-600" />
-        <h1 className="text-2xl font-semibold text-slate-900">Settings</h1>
+        <CogIcon className="h-8 w-8 text-slate-600 dark:text-slate-400" />
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Settings</h1>
       </div>
 
       {/* Profile Section */}
-      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm">
         <div className="flex items-center gap-3 mb-6">
-          <UserIcon className="h-6 w-6 text-slate-600" />
-          <h2 className="text-lg font-medium text-slate-900">Profile</h2>
+          <UserIcon className="h-6 w-6 text-slate-600 dark:text-slate-400" />
+          <h2 className="text-lg font-medium text-slate-900 dark:text-white">Profile</h2>
         </div>
 
         <form onSubmit={handleProfileSubmit} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               Email
             </label>
             <input
@@ -138,13 +138,13 @@ export function SettingsView({ user }: SettingsViewProps) {
               type="email"
               value={user.email}
               disabled
-              className="w-full rounded-md border border-slate-300 bg-slate-100 px-3 py-2 text-sm text-slate-500 cursor-not-allowed"
+              className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-700 px-3 py-2 text-sm text-slate-500 dark:text-slate-400 cursor-not-allowed"
             />
-            <p className="mt-1 text-xs text-slate-500">Email cannot be changed</p>
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Email cannot be changed</p>
           </div>
 
           <div>
-            <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="name" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               Name
             </label>
             <input
@@ -152,19 +152,19 @@ export function SettingsView({ user }: SettingsViewProps) {
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
               placeholder="Enter your name"
             />
           </div>
 
           {profileError && (
-            <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-600 dark:text-red-400">
               {profileError}
             </div>
           )}
 
           {profileSuccess && (
-            <div className="rounded-md bg-green-50 px-3 py-2 text-sm text-green-600">
+            <div className="rounded-md bg-green-50 dark:bg-green-900/20 px-3 py-2 text-sm text-green-600 dark:text-green-400">
               Profile updated successfully
             </div>
           )}
@@ -172,7 +172,7 @@ export function SettingsView({ user }: SettingsViewProps) {
           <button
             type="submit"
             disabled={profileLoading}
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="rounded-md bg-slate-900 dark:bg-white px-4 py-2 text-sm font-medium text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {profileLoading ? "Saving..." : "Save Profile"}
           </button>
@@ -180,10 +180,10 @@ export function SettingsView({ user }: SettingsViewProps) {
       </div>
 
       {/* Password Section */}
-      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm">
         <div className="flex items-center gap-3 mb-6">
           <svg
-            className="h-6 w-6 text-slate-600"
+            className="h-6 w-6 text-slate-600 dark:text-slate-400"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -195,12 +195,12 @@ export function SettingsView({ user }: SettingsViewProps) {
               d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
             />
           </svg>
-          <h2 className="text-lg font-medium text-slate-900">Change Password</h2>
+          <h2 className="text-lg font-medium text-slate-900 dark:text-white">Change Password</h2>
         </div>
 
         <form onSubmit={handlePasswordSubmit} className="space-y-4">
           <div>
-            <label htmlFor="currentPassword" className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="currentPassword" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               Current Password
             </label>
             <input
@@ -208,13 +208,13 @@ export function SettingsView({ user }: SettingsViewProps) {
               type="password"
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
               placeholder="Enter current password"
             />
           </div>
 
           <div>
-            <label htmlFor="newPassword" className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="newPassword" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               New Password
             </label>
             <input
@@ -222,14 +222,14 @@ export function SettingsView({ user }: SettingsViewProps) {
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
               placeholder="Enter new password"
             />
-            <p className="mt-1 text-xs text-slate-500">Must be at least 8 characters</p>
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Must be at least 8 characters</p>
           </div>
 
           <div>
-            <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               Confirm New Password
             </label>
             <input
@@ -237,19 +237,19 @@ export function SettingsView({ user }: SettingsViewProps) {
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
               placeholder="Confirm new password"
             />
           </div>
 
           {passwordError && (
-            <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-600 dark:text-red-400">
               {passwordError}
             </div>
           )}
 
           {passwordSuccess && (
-            <div className="rounded-md bg-green-50 px-3 py-2 text-sm text-green-600">
+            <div className="rounded-md bg-green-50 dark:bg-green-900/20 px-3 py-2 text-sm text-green-600 dark:text-green-400">
               Password changed successfully
             </div>
           )}
@@ -257,7 +257,7 @@ export function SettingsView({ user }: SettingsViewProps) {
           <button
             type="submit"
             disabled={passwordLoading}
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="rounded-md bg-slate-900 dark:bg-white px-4 py-2 text-sm font-medium text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {passwordLoading ? "Changing..." : "Change Password"}
           </button>

--- a/web/src/components/transactions/transactions-view.tsx
+++ b/web/src/components/transactions/transactions-view.tsx
@@ -92,12 +92,12 @@ interface FilterChipProps {
 
 function FilterChip({ label, value, onRemove }: FilterChipProps) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm text-slate-700">
-      <span className="text-slate-500">{label}:</span>
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 dark:bg-slate-700 px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300">
+      <span className="text-slate-500 dark:text-slate-400">{label}:</span>
       <span className="font-medium">{value}</span>
       <button
         onClick={onRemove}
-        className="ml-0.5 rounded-full p-0.5 hover:bg-slate-200 transition-colors min-h-[22px] min-w-[22px] flex items-center justify-center"
+        className="ml-0.5 rounded-full p-0.5 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors min-h-[22px] min-w-[22px] flex items-center justify-center"
         aria-label={`Remove ${label} filter`}
       >
         <XMarkIcon className="h-3.5 w-3.5" />
@@ -335,24 +335,24 @@ export default function TransactionsView({
     <div className="space-y-4 md:space-y-6">
       <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div>
-          <h1 className="text-2xl font-semibold text-slate-900">Transactions</h1>
-          <p className="text-sm text-slate-500">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Transactions</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
             Review, categorize, and annotate expenses grouped by credit card.
           </p>
         </div>
       </header>
 
       {/* Filter Section */}
-      <div className="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm overflow-hidden">
         {/* Primary Filters - Always visible */}
         <div className="p-4">
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
             {/* Search */}
             <div className="relative sm:col-span-2 md:col-span-1 md:order-first">
-              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 dark:text-slate-500" />
               <input
                 type="text"
-                className="w-full rounded-md border border-slate-300 pl-9 pr-3 py-2.5 text-sm text-slate-700 placeholder:text-slate-400 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 pl-9 pr-3 py-2.5 text-sm text-slate-700 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500 min-h-[44px] focus:border-slate-500 dark:focus:border-slate-400 focus:ring-1 focus:ring-slate-500 dark:focus:ring-slate-400 transition-colors"
                 placeholder="Search merchant or note..."
                 value={filters.search ?? ""}
                 onChange={(event) =>
@@ -362,10 +362,10 @@ export default function TransactionsView({
             </div>
 
             {/* Month */}
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Month
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-[44px] focus:border-slate-500 dark:focus:border-slate-400 focus:ring-1 focus:ring-slate-500 dark:focus:ring-slate-400 transition-colors"
                 value={filters.month}
                 onChange={(event) =>
                   setFilters((prev) => ({ ...prev, month: event.target.value ?? "" }))
@@ -385,14 +385,14 @@ export default function TransactionsView({
                 onClick={() => setShowMoreFilters(!showMoreFilters)}
                 className={`flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-colors min-h-[44px] w-full justify-center ${
                   showMoreFilters || activeAdvancedFilterCount > 0
-                    ? "bg-slate-100 text-slate-900"
-                    : "bg-slate-50 text-slate-600 hover:bg-slate-100"
+                    ? "bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-white"
+                    : "bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600"
                 }`}
               >
                 <FunnelIcon className="h-4 w-4" />
                 More Filters
                 {activeAdvancedFilterCount > 0 && (
-                  <span className="ml-1 rounded-full bg-slate-800 px-2 py-0.5 text-xs text-white">
+                  <span className="ml-1 rounded-full bg-slate-800 dark:bg-slate-500 px-2 py-0.5 text-xs text-white dark:text-slate-900">
                     {activeAdvancedFilterCount}
                   </span>
                 )}
@@ -404,12 +404,12 @@ export default function TransactionsView({
 
         {/* Advanced Filters - Expandable */}
         {showMoreFilters && (
-          <div className="border-t border-slate-200 bg-slate-50 p-4">
+          <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-700/50 p-4">
             <div className="grid gap-4 grid-cols-1 sm:grid-cols-3">
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Card
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-[44px] focus:border-slate-500 dark:focus:border-slate-400 focus:ring-1 focus:ring-slate-500 dark:focus:ring-slate-400 transition-colors"
                   value={filters.cardId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -426,10 +426,10 @@ export default function TransactionsView({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Owner
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-[44px] focus:border-slate-500 dark:focus:border-slate-400 focus:ring-1 focus:ring-slate-500 dark:focus:ring-slate-400 transition-colors"
                   value={filters.ownerId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -446,10 +446,10 @@ export default function TransactionsView({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Category
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-white min-h-[44px] focus:border-slate-500 dark:focus:border-slate-400 focus:ring-1 focus:ring-slate-500 dark:focus:ring-slate-400 transition-colors"
                   value={filters.categoryId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -472,8 +472,8 @@ export default function TransactionsView({
 
         {/* Active Filter Chips */}
         {activeFilters.length > 0 && (
-          <div className="border-t border-slate-200 px-4 py-3 flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium text-slate-500 uppercase tracking-wide mr-1">
+          <div className="border-t border-slate-200 dark:border-slate-700 px-4 py-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide mr-1">
               Active:
             </span>
             {activeFilters.map((filter) => (
@@ -486,7 +486,7 @@ export default function TransactionsView({
             ))}
             <button
               onClick={clearAllFilters}
-              className="ml-auto text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors px-2 py-1 min-h-[32px]"
+              className="ml-auto text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors px-2 py-1 min-h-[32px]"
             >
               Clear all
             </button>
@@ -495,7 +495,7 @@ export default function TransactionsView({
       </div>
 
       {errorMessage && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-600 dark:text-red-400">
           {errorMessage}
         </div>
       )}
@@ -519,27 +519,27 @@ export default function TransactionsView({
             }}
           />
         ) : (
-          <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500 text-center">
+          <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-sm text-slate-500 dark:text-slate-400 text-center">
             No transactions match the current filters.
           </div>
         )
       ) : (
         <div className="space-y-4 md:space-y-6">
           {groupedByCard.map(({ cardId, card, transactions: rows }) => (
-            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 bg-white p-3 md:p-4 shadow-sm">
-              <header className="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-100 pb-3 gap-2">
+            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 md:p-4 shadow-sm">
+              <header className="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-100 dark:border-slate-700 pb-3 gap-2">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
                     {card?.name ?? cardId}
                   </h2>
-                  <p className="text-xs uppercase tracking-wide text-slate-500">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     {rows.length} transactions
                   </p>
                 </div>
-                <div className="text-left sm:text-right text-sm text-slate-600">
+                <div className="text-left sm:text-right text-sm text-slate-600 dark:text-slate-400">
                   <p>
                     Total spent:{" "}
-                    <span className="font-medium">
+                    <span className="font-medium text-slate-900 dark:text-white">
                       {formatMoney(
                         rows.reduce(
                           (acc, tx) => (tx.amount < 0 ? acc + Math.abs(tx.amount) : acc),
@@ -551,7 +551,7 @@ export default function TransactionsView({
                   </p>
                   <p>
                     Net:{" "}
-                    <span className="font-medium">
+                    <span className="font-medium text-slate-900 dark:text-white">
                       {formatMoney(
                         rows.reduce((acc, tx) => acc + tx.amount, 0),
                         currency,
@@ -565,33 +565,33 @@ export default function TransactionsView({
                 {rows.map((row) => (
                   <div
                     key={row.id}
-                    className="rounded-lg border border-slate-100 bg-slate-50 p-4 space-y-3"
+                    className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4 space-y-3"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0 flex-1">
-                        <p className="font-medium text-slate-900 truncate">{row.merchant}</p>
+                        <p className="font-medium text-slate-900 dark:text-white truncate">{row.merchant}</p>
                         {row.description && (
-                          <p className="text-xs text-slate-500 truncate">{row.description}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{row.description}</p>
                         )}
                       </div>
-                      <p className="font-semibold text-slate-900 whitespace-nowrap">
+                      <p className="font-semibold text-slate-900 dark:text-white whitespace-nowrap">
                         {formatMoney(row.amount, row.currency)}
                       </p>
                     </div>
-                    <div className="flex items-center justify-between text-sm text-slate-600">
+                    <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
                       <span>{format(new Date(row.transaction_date), "dd MMM yyyy")}</span>
                       {row.original_currency && row.original_amount !== undefined && (
-                        <span className="text-xs text-slate-500">
+                        <span className="text-xs text-slate-500 dark:text-slate-400">
                           {`${row.original_currency} ${Math.abs(row.original_amount).toFixed(2)}`}
                         </span>
                       )}
                     </div>
                     <div className="grid grid-cols-2 gap-3">
-                      <label className="flex flex-col text-xs font-medium text-slate-500">
+                      <label className="flex flex-col text-xs font-medium text-slate-500 dark:text-slate-400">
                         Owner
                         <select
                           value={row.owner_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
+                          className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-600 px-2 py-2 text-sm text-slate-700 dark:text-white min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, { owner_id: event.target.value })
                           }
@@ -604,11 +604,11 @@ export default function TransactionsView({
                           ))}
                         </select>
                       </label>
-                      <label className="flex flex-col text-xs font-medium text-slate-500">
+                      <label className="flex flex-col text-xs font-medium text-slate-500 dark:text-slate-400">
                         Category
                         <select
                           value={row.category_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
+                          className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-600 px-2 py-2 text-sm text-slate-700 dark:text-white min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, {
                               category_id: event.target.value,
@@ -626,11 +626,11 @@ export default function TransactionsView({
                       </label>
                     </div>
                     {row.notes && (
-                      <p className="text-xs text-slate-600">Notes: {row.notes}</p>
+                      <p className="text-xs text-slate-600 dark:text-slate-400">Notes: {row.notes}</p>
                     )}
-                    <div className="flex justify-end pt-2 border-t border-slate-200">
+                    <div className="flex justify-end pt-2 border-t border-slate-200 dark:border-slate-600">
                       <button
-                        className="min-h-[44px] min-w-[44px] px-4 py-2 text-sm font-semibold text-red-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        className="min-h-[44px] min-w-[44px] px-4 py-2 text-sm font-semibold text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
                         onClick={() => deleteTransactionRow(row)}
                         disabled={savingId === row.id}
                       >
@@ -643,9 +643,9 @@ export default function TransactionsView({
 
               {/* Desktop table view */}
               <div className="hidden md:block overflow-x-auto">
-                <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                   <thead>
-                    <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                       <th className="px-3 py-2">Date</th>
                       <th className="px-3 py-2">Merchant</th>
                       <th className="px-3 py-2">Owner</th>
@@ -655,20 +655,20 @@ export default function TransactionsView({
                       <th className="px-3 py-2 text-right">Actions</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-slate-100 text-slate-700">
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                     {rows.map((row) => (
-                      <tr key={row.id} className="hover:bg-slate-50">
+                      <tr key={row.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/50">
                         <td className="whitespace-nowrap px-3 py-2 font-medium">
                           {format(new Date(row.transaction_date), "dd MMM yyyy")}
                         </td>
                         <td className="px-3 py-2">
-                          <div className="font-medium text-slate-900">{row.merchant}</div>
-                          <div className="text-xs text-slate-500">{row.description}</div>
+                          <div className="font-medium text-slate-900 dark:text-white">{row.merchant}</div>
+                          <div className="text-xs text-slate-500 dark:text-slate-400">{row.description}</div>
                         </td>
                         <td className="px-3 py-2">
                           <select
                             value={row.owner_id}
-                            className="w-36 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                            className="w-36 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-2 py-1 text-xs text-slate-700 dark:text-white"
                             onChange={(event) =>
                               updateTransaction(row, { owner_id: event.target.value })
                             }
@@ -684,7 +684,7 @@ export default function TransactionsView({
                         <td className="px-3 py-2">
                           <select
                             value={row.category_id}
-                            className="w-40 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                            className="w-40 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-2 py-1 text-xs text-slate-700 dark:text-white"
                             onChange={(event) =>
                               updateTransaction(row, {
                                 category_id: event.target.value,
@@ -700,10 +700,10 @@ export default function TransactionsView({
                             ))}
                           </select>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-900">
+                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-900 dark:text-white">
                           {formatMoney(row.amount, row.currency)}
                           {row.original_currency && row.original_amount !== undefined && (
-                            <div className="text-xs text-slate-500">
+                            <div className="text-xs text-slate-500 dark:text-slate-400">
                               {`${row.original_currency} ${Math.abs(row.original_amount).toFixed(2)}`}
                               {row.fx_rate && row.original_currency !== row.currency ? (
                                 <span className="ml-1">({row.fx_rate.toFixed(4)} FX)</span>
@@ -711,12 +711,12 @@ export default function TransactionsView({
                             </div>
                           )}
                         </td>
-                        <td className="px-3 py-2 text-xs text-slate-600">
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-400">
                           {row.notes ?? "-"}
                         </td>
                         <td className="px-3 py-2 text-right">
                           <button
-                            className="text-xs font-semibold text-red-500 hover:text-red-600"
+                            className="text-xs font-semibold text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300"
                             onClick={() => deleteTransactionRow(row)}
                             disabled={savingId === row.id}
                           >

--- a/web/src/components/ui/drop-zone.tsx
+++ b/web/src/components/ui/drop-zone.tsx
@@ -150,21 +150,21 @@ export function DropZone({
         onDrop={handleDrop}
         className={cn(
           'relative flex flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-all duration-200 cursor-pointer',
-          state === 'idle' && 'border-slate-300 bg-slate-50 hover:border-slate-400 hover:bg-slate-100',
-          state === 'dragover' && 'border-blue-500 bg-blue-50 scale-[1.02]',
-          state === 'uploading' && 'border-blue-400 bg-blue-50 cursor-wait',
-          state === 'success' && 'border-emerald-500 bg-emerald-50',
-          state === 'error' && 'border-red-400 bg-red-50'
+          state === 'idle' && 'border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700',
+          state === 'dragover' && 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 scale-[1.02]',
+          state === 'uploading' && 'border-blue-400 bg-blue-50 dark:bg-blue-900/20 cursor-wait',
+          state === 'success' && 'border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20',
+          state === 'error' && 'border-red-400 bg-red-50 dark:bg-red-900/20'
         )}
       >
         {/* Icon */}
         <div className={cn(
           'mb-4 rounded-full p-4 transition-colors',
-          state === 'idle' && 'bg-slate-200 text-slate-500',
-          state === 'dragover' && 'bg-blue-200 text-blue-600',
-          state === 'uploading' && 'bg-blue-200 text-blue-600',
-          state === 'success' && 'bg-emerald-200 text-emerald-600',
-          state === 'error' && 'bg-red-200 text-red-600'
+          state === 'idle' && 'bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400',
+          state === 'dragover' && 'bg-blue-200 dark:bg-blue-800 text-blue-600 dark:text-blue-400',
+          state === 'uploading' && 'bg-blue-200 dark:bg-blue-800 text-blue-600 dark:text-blue-400',
+          state === 'success' && 'bg-emerald-200 dark:bg-emerald-800 text-emerald-600 dark:text-emerald-400',
+          state === 'error' && 'bg-red-200 dark:bg-red-800 text-red-600 dark:text-red-400'
         )}>
           {state === 'success' ? (
             <CheckIcon className="h-8 w-8" />
@@ -178,13 +178,13 @@ export function DropZone({
         {/* Text content */}
         {state === 'idle' && (
           <>
-            <p className="text-base font-medium text-slate-700">
+            <p className="text-base font-medium text-slate-700 dark:text-slate-300">
               Drag PDF statement here
             </p>
-            <p className="mt-1 text-sm text-slate-500">
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               or click to browse
             </p>
-            <p className="mt-3 text-xs text-slate-400">
+            <p className="mt-3 text-xs text-slate-400 dark:text-slate-500">
               PDF statements from Turkish banks (max {maxSizeMB}MB)
             </p>
           </>
@@ -192,10 +192,10 @@ export function DropZone({
 
         {state === 'dragover' && (
           <>
-            <p className="text-base font-medium text-blue-700">
+            <p className="text-base font-medium text-blue-700 dark:text-blue-400">
               Drop your file here
             </p>
-            <p className="mt-1 text-sm text-blue-500">
+            <p className="mt-1 text-sm text-blue-500 dark:text-blue-400">
               Release to upload
             </p>
           </>
@@ -203,31 +203,31 @@ export function DropZone({
 
         {state === 'uploading' && (
           <>
-            <p className="text-base font-medium text-blue-700">
+            <p className="text-base font-medium text-blue-700 dark:text-blue-400">
               Processing...
             </p>
-            <p className="mt-1 text-sm text-blue-500">
+            <p className="mt-1 text-sm text-blue-500 dark:text-blue-400">
               {fileName}
             </p>
             {/* Progress bar */}
             <div className="mt-4 w-full max-w-xs">
-              <div className="h-2 w-full overflow-hidden rounded-full bg-blue-200">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-blue-200 dark:bg-blue-800">
                 <div
-                  className="h-full bg-blue-600 transition-all duration-300"
+                  className="h-full bg-blue-600 dark:bg-blue-400 transition-all duration-300"
                   style={{ width: `${progress}%` }}
                 />
               </div>
-              <p className="mt-1 text-center text-xs text-blue-600">{progress}%</p>
+              <p className="mt-1 text-center text-xs text-blue-600 dark:text-blue-400">{progress}%</p>
             </div>
           </>
         )}
 
         {state === 'success' && (
           <>
-            <p className="text-base font-medium text-emerald-700">
+            <p className="text-base font-medium text-emerald-700 dark:text-emerald-400">
               File ready
             </p>
-            <p className="mt-1 text-sm text-emerald-600">
+            <p className="mt-1 text-sm text-emerald-600 dark:text-emerald-400">
               {fileName} ({fileSize ? formatFileSize(fileSize) : ''})
             </p>
             <button
@@ -236,7 +236,7 @@ export function DropZone({
                 e.stopPropagation();
                 handleReset();
               }}
-              className="mt-3 text-xs text-emerald-700 underline hover:text-emerald-800"
+              className="mt-3 text-xs text-emerald-700 dark:text-emerald-400 underline hover:text-emerald-800 dark:hover:text-emerald-300"
             >
               Choose a different file
             </button>
@@ -245,10 +245,10 @@ export function DropZone({
 
         {state === 'error' && (
           <>
-            <p className="text-base font-medium text-red-700">
+            <p className="text-base font-medium text-red-700 dark:text-red-400">
               Upload failed
             </p>
-            <p className="mt-1 text-sm text-red-600">
+            <p className="mt-1 text-sm text-red-600 dark:text-red-400">
               {error}
             </p>
             <button
@@ -257,7 +257,7 @@ export function DropZone({
                 e.stopPropagation();
                 handleReset();
               }}
-              className="mt-3 text-xs text-red-700 underline hover:text-red-800"
+              className="mt-3 text-xs text-red-700 dark:text-red-400 underline hover:text-red-800 dark:hover:text-red-300"
             >
               Try again
             </button>

--- a/web/src/components/ui/empty-state.tsx
+++ b/web/src/components/ui/empty-state.tsx
@@ -35,18 +35,18 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white p-8 shadow-sm text-center",
+        "flex flex-col items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-8 shadow-sm text-center",
         className
       )}
     >
       {icon && (
-        <div className="mb-4 text-slate-400">
+        <div className="mb-4 text-slate-400 dark:text-slate-500">
           {icon}
         </div>
       )}
-      <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
       {description && (
-        <p className="mt-2 text-sm text-slate-500 max-w-sm">{description}</p>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400 max-w-sm">{description}</p>
       )}
       {children && (
         <div className="mt-4 w-full max-w-sm">{children}</div>
@@ -54,7 +54,7 @@ export function EmptyState({
       {action && (
         <Link
           href={action.href}
-          className="mt-6 inline-flex items-center justify-center rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          className="mt-6 inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-white px-5 py-2.5 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
         >
           {action.label}
         </Link>


### PR DESCRIPTION
## Summary
- Add dark mode Tailwind classes to 7 components that were missing dark variants
- Fix white backgrounds on Categories, Transactions, Settings, Imports, and Pending Imports pages
- Apply consistent dark mode patterns: `bg-white dark:bg-slate-800`, `text-slate-900 dark:text-white`, etc.

### Files Changed
- `categories-manager.tsx`: Headers, alerts, quick add presets, custom category form, categories list/table, mobile cards
- `transactions-view.tsx`: Filters section, search input, selects, filter chips, error messages, transaction cards, mobile view, tables
- `settings-view.tsx`: Profile and password sections, form labels, inputs, error/success messages, buttons
- `imports-view.tsx`: Extraction card, preview section with form inputs, success/error states
- `pending-imports-view.tsx`: Run cards, stats grids, warnings, sample transactions, action buttons
- `drop-zone.tsx`: All states (idle, dragover, uploading, success, error), icon backgrounds, progress bar
- `empty-state.tsx`: Container, icon, title, description, action button

## Test plan
- [ ] Verify dark mode styling on Categories page
- [ ] Verify dark mode styling on Transactions page
- [ ] Verify dark mode styling on Settings page
- [ ] Verify dark mode styling on Imports page
- [ ] Verify dark mode styling on Pending Imports page
- [ ] Verify drop zone component in all states
- [ ] Verify empty state component displays correctly
- [ ] Run lint, type-check, and tests (all passed)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)