### PR TITLE
fix(ui): add dark mode support to import history page

### DIFF
--- a/web/src/components/imports/import-history-view.tsx
+++ b/web/src/components/imports/import-history-view.tsx
@@ -99,19 +99,19 @@ export default function ImportHistoryView({ initialHistory }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Import history</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Import history</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           View all completed statement imports. You can delete an import to remove all associated transactions.
         </p>
       </header>
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-600 dark:text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+        <div className="rounded-md border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-4 text-sm text-emerald-700 dark:text-emerald-400">
           {success}
         </div>
       )}
@@ -137,60 +137,60 @@ export default function ImportHistoryView({ initialHistory }: Props) {
           {history.map((run) => (
             <div
               key={run.run_id}
-              className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+              className="space-y-4 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm"
             >
               <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
                 <div>
-                  <p className="text-sm font-medium text-slate-500">Run ID</p>
-                  <p className="font-mono text-slate-900">{run.run_id}</p>
+                  <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Run ID</p>
+                  <p className="font-mono text-slate-900 dark:text-white">{run.run_id}</p>
                 </div>
-                <div className="text-sm text-slate-500">
+                <div className="text-sm text-slate-500 dark:text-slate-400">
                   <p>
                     Imported on {format(new Date(run.imported_at), "PPpp")}
                   </p>
                   <p>
-                    Statement: <span className="font-medium text-slate-900">{run.statement_file}</span>
+                    Statement: <span className="font-medium text-slate-900 dark:text-white">{run.statement_file}</span>
                   </p>
                 </div>
               </div>
 
               <div className="grid gap-4 sm:grid-cols-4">
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Statement Period</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Statement Period</p>
+                  <p className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">
                     {run.statement_month
                       ? formatStatementPeriod(run.statement_month)
                       : formatStatementPeriod(run.month)}
                   </p>
-                  <p className="text-xs text-slate-500">Billing cycle</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Billing cycle</p>
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Transactions</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Transactions</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {run.summary?.transactions ?? 0}
                   </p>
-                  <p className="text-xs text-slate-500">{run.month}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{run.month}</p>
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Total spend</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Total spend</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {run.summary
                       ? formatMoney(run.summary.total_spend, run.summary.currency)
                       : "-"}
                   </p>
-                  <p className="text-xs text-slate-500">Net of refunds</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Net of refunds</p>
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Status</p>
-                  <p className="mt-2 text-sm font-medium text-slate-900 capitalize">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Status</p>
+                  <p className="mt-2 text-sm font-medium text-slate-900 dark:text-white capitalize">
                     {run.status}
                   </p>
-                  <p className="text-xs text-slate-500">Card: {run.card_id}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Card: {run.card_id}</p>
                 </div>
               </div>
 
               {run.error && (
-                <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-700 dark:text-red-400">
                   <p className="font-medium">Error</p>
                   <p>{run.error}</p>
                 </div>
@@ -198,11 +198,11 @@ export default function ImportHistoryView({ initialHistory }: Props) {
 
               {/* Delete confirmation dialog */}
               {confirmDeleteId === run.run_id ? (
-                <div className="rounded-md border border-amber-200 bg-amber-50 p-4">
-                  <p className="text-sm font-medium text-amber-800">
+                <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4">
+                  <p className="text-sm font-medium text-amber-800 dark:text-amber-400">
                     Are you sure you want to delete this import?
                   </p>
-                  <p className="mt-1 text-sm text-amber-700">
+                  <p className="mt-1 text-sm text-amber-700 dark:text-amber-500">
                     This will permanently delete the import run and all {run.summary?.transactions ?? 0} associated transactions.
                     This action cannot be undone.
                   </p>
@@ -211,7 +211,7 @@ export default function ImportHistoryView({ initialHistory }: Props) {
                       type="button"
                       onClick={() => handleDelete(run.run_id)}
                       disabled={deletingId === run.run_id}
-                      className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+                      className="rounded-md bg-red-600 dark:bg-red-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500 dark:hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
                     >
                       {deletingId === run.run_id ? "Deleting..." : "Yes, delete import"}
                     </button>
@@ -219,7 +219,7 @@ export default function ImportHistoryView({ initialHistory }: Props) {
                       type="button"
                       onClick={cancelDelete}
                       disabled={deletingId === run.run_id}
-                      className="rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
+                      className="rounded-md border border-slate-300 dark:border-slate-600 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 shadow-sm transition hover:bg-slate-100 dark:hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 min-h-11"
                     >
                       Cancel
                     </button>
@@ -230,7 +230,7 @@ export default function ImportHistoryView({ initialHistory }: Props) {
                   <button
                     type="button"
                     onClick={() => confirmDelete(run.run_id)}
-                    className="rounded-md border border-red-300 px-4 py-2 text-sm font-semibold text-red-600 shadow-sm transition hover:bg-red-50 min-h-11 w-full md:w-auto"
+                    className="rounded-md border border-red-300 dark:border-red-700 px-4 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm transition hover:bg-red-50 dark:hover:bg-red-900/20 min-h-11 w-full md:w-auto"
                   >
                     Delete import
                   </button>


### PR DESCRIPTION
## Summary
- Add dark mode variant classes to `import-history-view.tsx`
- Fix white background issue when viewing import history in dark mode
- Matches the dark mode styling patterns used in other pages (PR #76)

## Changes
- Header and description text: `dark:text-white`, `dark:text-slate-400`
- Error/success alerts: `dark:bg-red-900/20`, `dark:bg-emerald-900/20`
- Import run cards: `dark:bg-slate-800`, `dark:border-slate-700`
- Stats grid: consistent dark backgrounds and text colors
- Delete dialog: `dark:bg-amber-900/20` with amber-themed text
- Buttons: appropriate dark hover states

## Test plan
- [ ] View import history page in light mode - should look unchanged
- [ ] View import history page in dark mode - should have dark backgrounds
- [ ] Check error/success alerts styling in both modes
- [ ] Check delete confirmation dialog styling in both modes

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)