### PR TITLE
fix(ui): add dark mode support to transactions, imports, and pending imports pages

### DIFF
--- a/web/src/components/imports/imports-view.tsx
+++ b/web/src/components/imports/imports-view.tsx
@@ -137,8 +137,8 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Statement import</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Statement import</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           Upload a PDF statement and we will automatically extract transactions, match your card and owner.
         </p>
       </header>
@@ -154,11 +154,11 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
 
       {/* Step 2: Extract & Preview button */}
       {statementPdfBase64 && !showPreview && (
-        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-slate-700">Ready to extract</p>
-              <p className="text-xs text-slate-500 mt-1">
+              <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Ready to extract</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                 {fileName} - Uses Claude AI to extract transactions
               </p>
             </div>
@@ -166,7 +166,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
               type="button"
               onClick={handleExtractPreview}
               disabled={isExtracting}
-              className="rounded-md bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              className="rounded-md bg-slate-900 dark:bg-slate-100 px-5 py-2.5 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-200 disabled:cursor-not-allowed disabled:bg-slate-400 dark:disabled:bg-slate-600"
             >
               {isExtracting ? (
                 <span className="flex items-center gap-2">
@@ -183,32 +183,32 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
 
       {/* Step 3: Show extracted preview with edit capability */}
       {showPreview && extractedMetadata && (
-        <div className="space-y-4 rounded-xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
           <div>
-            <p className="text-base font-semibold text-emerald-800">Extraction complete</p>
-            <p className="text-sm text-emerald-600">Review and confirm the extracted information</p>
+            <p className="text-base font-semibold text-emerald-800 dark:text-emerald-400">Extraction complete</p>
+            <p className="text-sm text-emerald-600 dark:text-emerald-500">Review and confirm the extracted information</p>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Month
               <input
                 type="month"
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800"
                 value={month}
                 onChange={(event) => setMonth(event.target.value)}
               />
               {extractedMetadata.statement_month && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Detected: {extractedMetadata.statement_month}
                 </span>
               )}
             </label>
 
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Card
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800"
                 value={cardId}
                 onChange={(event) => setCardId(event.target.value)}
               >
@@ -219,16 +219,16 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 ))}
               </select>
               {extractedMetadata.card_last4 && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Matched: ****{extractedMetadata.card_last4}
                 </span>
               )}
             </label>
 
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-400">
               Owner
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 bg-white"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800"
                 value={ownerId}
                 onChange={(event) => setOwnerId(event.target.value)}
               >
@@ -239,7 +239,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 ))}
               </select>
               {extractedMetadata.cardholder_name && (
-                <span className="mt-1 text-xs text-emerald-600">
+                <span className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
                   Matched: {extractedMetadata.cardholder_name}
                 </span>
               )}
@@ -250,7 +250,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
             <button
               type="button"
               onClick={handleConfirmImport}
-              className="rounded-md bg-emerald-700 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600"
+              className="rounded-md bg-emerald-700 dark:bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600 dark:hover:bg-emerald-500"
             >
               Confirm Import
             </button>
@@ -260,7 +260,7 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 setShowPreview(false);
                 setExtractedMetadata(null);
               }}
-              className="rounded-md bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition hover:bg-slate-50"
+              className="rounded-md bg-white dark:bg-slate-800 px-5 py-2.5 text-sm font-semibold text-slate-700 dark:text-slate-200 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-600 transition hover:bg-slate-50 dark:hover:bg-slate-700"
             >
               Cancel
             </button>
@@ -269,23 +269,23 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
       )}
 
       {error && (
-        <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
-          <ErrorIcon className="h-5 w-5 flex-shrink-0 text-red-500 mt-0.5" />
+        <div className="flex items-start gap-3 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4">
+          <ErrorIcon className="h-5 w-5 flex-shrink-0 text-red-500 dark:text-red-400 mt-0.5" />
           <div>
-            <p className="text-sm font-medium text-red-800">Import failed</p>
-            <p className="text-sm text-red-600 mt-1">{error}</p>
+            <p className="text-sm font-medium text-red-800 dark:text-red-400">Import failed</p>
+            <p className="text-sm text-red-600 dark:text-red-500 mt-1">{error}</p>
           </div>
         </div>
       )}
 
       {response && !showPreview && (
-        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm">
+        <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-6 shadow-sm">
           <div className="flex items-start gap-3">
-            <SuccessIcon className="h-6 w-6 flex-shrink-0 text-emerald-500 mt-0.5" />
+            <SuccessIcon className="h-6 w-6 flex-shrink-0 text-emerald-500 dark:text-emerald-400 mt-0.5" />
             <div>
-              <p className="text-base font-semibold text-emerald-800">Import queued</p>
-              <p className="mt-1 text-sm text-emerald-700">
-                <span className="font-mono text-xs bg-emerald-100 px-1.5 py-0.5 rounded">{response.runId}</span>
+              <p className="text-base font-semibold text-emerald-800 dark:text-emerald-400">Import queued</p>
+              <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-500">
+                <span className="font-mono text-xs bg-emerald-100 dark:bg-emerald-800/50 px-1.5 py-0.5 rounded">{response.runId}</span>
                 {" "}&bull;{" "}
                 {response.summary.transactions} transactions
                 {" "}&bull;{" "}
@@ -295,13 +295,13 @@ export default function ImportsView({ cards, owners, defaultMonth }: Props) {
                 })}
               </p>
               {response.warnings.length > 0 && (
-                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-emerald-800">
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-emerald-800 dark:text-emerald-400">
                   {response.warnings.map((warning) => (
                     <li key={warning}>{warning}</li>
                   ))}
                 </ul>
               )}
-              <p className="mt-3 text-xs text-emerald-600">
+              <p className="mt-3 text-xs text-emerald-600 dark:text-emerald-500">
                 {response.autoCommitted
                   ? "Transactions were written to the ledger automatically."
                   : "Review the pending import to approve and commit."}

--- a/web/src/components/imports/pending-imports-view.tsx
+++ b/web/src/components/imports/pending-imports-view.tsx
@@ -129,19 +129,19 @@ export default function PendingImportsView({ initialRuns }: Props) {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Pending imports</h1>
-        <p className="text-sm text-slate-500">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Pending imports</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
           Review staged LLM extractions and approve them to merge into your ledger.
         </p>
       </header>
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-600 dark:text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+        <div className="rounded-md border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 p-4 text-sm text-emerald-700 dark:text-emerald-400">
           {success}
         </div>
       )}
@@ -166,51 +166,51 @@ export default function PendingImportsView({ initialRuns }: Props) {
             {runs.map((run) => (
               <div
                 key={run.run_id}
-                className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+                className="space-y-4 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm"
               >
               <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
                 <div>
-                  <p className="text-sm font-medium text-slate-500">Run ID</p>
-                  <p className="font-mono text-slate-900">{run.run_id}</p>
+                  <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Run ID</p>
+                  <p className="font-mono text-slate-900 dark:text-white">{run.run_id}</p>
                 </div>
-                <div className="text-sm text-slate-500">
+                <div className="text-sm text-slate-500 dark:text-slate-400">
                   <p>
                     Saved on {format(new Date(run.saved_at), "PPpp")}
                   </p>
                   <p>
-                    Statement: <span className="font-medium text-slate-900">{run.statement_file}</span>
+                    Statement: <span className="font-medium text-slate-900 dark:text-white">{run.statement_file}</span>
                   </p>
                 </div>
               </div>
 
               <div className="grid gap-4 sm:grid-cols-3">
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Transactions</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Transactions</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {run.summary.transactions}
                   </p>
                   {run.month && (
-                    <p className="text-xs text-slate-500">{run.month}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{run.month}</p>
                   )}
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Estimated spend</p>
-                  <p className="mt-2 text-xl font-semibold text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Estimated spend</p>
+                  <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
                     {formatMoney(run.summary.total_spend, run.summary.currency)}
                   </p>
-                  <p className="text-xs text-slate-500">Net of refunds</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">Net of refunds</p>
                 </div>
-                <div className="rounded-lg border border-slate-100 bg-slate-50 p-4">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Card / Owner</p>
-                  <p className="mt-2 text-sm font-medium text-slate-900">
+                <div className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Card / Owner</p>
+                  <p className="mt-2 text-sm font-medium text-slate-900 dark:text-white">
                     {run.card_id ?? "Unknown card"}
                   </p>
-                  <p className="text-xs text-slate-500">{run.owner_id ?? "Unassigned"}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{run.owner_id ?? "Unassigned"}</p>
                 </div>
               </div>
 
               {run.warnings.length > 0 && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+                <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4 text-sm text-amber-700 dark:text-amber-400">
                   <p className="font-medium">Warnings</p>
                   <ul className="list-disc space-y-1 pl-5">
                     {run.warnings.map((warning) => (
@@ -221,11 +221,11 @@ export default function PendingImportsView({ initialRuns }: Props) {
               )}
 
               <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                   Sample transactions
                 </p>
               {run.sample_transactions.length === 0 ? (
-                <p className="mt-2 text-sm text-slate-500">
+                <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                   No transactions extracted in this run.
                 </p>
               ) : (
@@ -235,18 +235,18 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     {run.sample_transactions.map((tx) => (
                       <div
                         key={tx.id}
-                        className="rounded-lg border border-slate-100 bg-slate-50 p-3"
+                        className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-3"
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <p className="font-medium text-slate-900 truncate">{tx.merchant}</p>
-                            <p className="text-xs text-slate-500">{tx.card_id}</p>
+                            <p className="font-medium text-slate-900 dark:text-white truncate">{tx.merchant}</p>
+                            <p className="text-xs text-slate-500 dark:text-slate-400">{tx.card_id}</p>
                           </div>
-                          <p className="font-semibold text-slate-900 flex-shrink-0">
+                          <p className="font-semibold text-slate-900 dark:text-white flex-shrink-0">
                             {formatMoney(tx.amount, run.summary.currency)}
                           </p>
                         </div>
-                        <p className="mt-1 text-xs text-slate-500">
+                        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                           {format(new Date(tx.transaction_date), "dd MMM yyyy")}
                         </p>
                       </div>
@@ -255,16 +255,16 @@ export default function PendingImportsView({ initialRuns }: Props) {
 
                   {/* Desktop table view for sample transactions */}
                   <div className="mt-3 hidden md:block overflow-x-auto">
-                    <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                       <thead>
-                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                           <th className="px-3 py-2">Date</th>
                           <th className="px-3 py-2">Merchant</th>
                           <th className="px-3 py-2">Card</th>
                           <th className="px-3 py-2 text-right">Amount</th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-slate-100 text-slate-700">
+                      <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                         {run.sample_transactions.map((tx) => (
                           <tr key={tx.id}>
                             <td className="whitespace-nowrap px-3 py-2">
@@ -283,7 +283,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                 </>
               )}
               {run.sample_count < run.total_transactions && (
-                <p className="mt-2 text-xs text-slate-500">
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
                   Showing first {run.sample_count} of {run.total_transactions} transactions.
                   {run.months.length > 1 && (
                     <span className="ml-1">
@@ -295,8 +295,8 @@ export default function PendingImportsView({ initialRuns }: Props) {
               </div>
 
               {expandedRun === run.run_id && details[run.run_id] && (
-                <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     All transactions ({details[run.run_id].transactions.length})
                   </p>
 
@@ -305,26 +305,26 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     {details[run.run_id].transactions.map((tx) => (
                       <div
                         key={tx.id}
-                        className="rounded-lg border border-slate-200 bg-white p-3 space-y-2"
+                        className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 p-3 space-y-2"
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <p className="font-medium text-slate-900 truncate">{tx.merchant}</p>
+                            <p className="font-medium text-slate-900 dark:text-white truncate">{tx.merchant}</p>
                             {tx.description && (
-                              <p className="text-xs text-slate-500 truncate">{tx.description}</p>
+                              <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{tx.description}</p>
                             )}
                           </div>
-                          <p className="font-semibold text-slate-900 flex-shrink-0">
+                          <p className="font-semibold text-slate-900 dark:text-white flex-shrink-0">
                             {formatMoney(tx.amount, run.summary.currency)}
                           </p>
                         </div>
-                        <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+                        <div className="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
                           <span>{format(new Date(tx.transaction_date), "dd MMM yyyy")}</span>
                           <span>Card: {tx.card_id}</span>
                           {tx.owner_id && <span>Owner: {tx.owner_id}</span>}
                         </div>
                         {tx.original_currency && (
-                          <p className="text-xs text-slate-500">
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
                             Original: {tx.original_currency} {Math.abs(tx.original_amount ?? 0).toFixed(2)}
                           </p>
                         )}
@@ -334,9 +334,9 @@ export default function PendingImportsView({ initialRuns }: Props) {
 
                   {/* Desktop table view for all transactions */}
                   <div className="mt-3 hidden md:block overflow-x-auto">
-                    <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                       <thead>
-                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                        <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                           <th className="px-3 py-2">Date</th>
                           <th className="px-3 py-2">Merchant</th>
                           <th className="px-3 py-2">Description</th>
@@ -346,19 +346,19 @@ export default function PendingImportsView({ initialRuns }: Props) {
                           <th className="px-3 py-2 text-right">Amount</th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-slate-100 text-slate-700">
+                      <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                         {details[run.run_id].transactions.map((tx) => (
                           <tr key={tx.id}>
                             <td className="whitespace-nowrap px-3 py-2">
                               {format(new Date(tx.transaction_date), "dd MMM yyyy")}
                             </td>
                             <td className="px-3 py-2">{tx.merchant}</td>
-                            <td className="px-3 py-2 text-xs text-slate-500">
+                            <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400">
                               {tx.description ?? "-"}
                             </td>
                             <td className="px-3 py-2">{tx.card_id}</td>
                             <td className="px-3 py-2">{tx.owner_id ?? "-"}</td>
-                            <td className="whitespace-nowrap px-3 py-2 text-right text-xs text-slate-500">
+                            <td className="whitespace-nowrap px-3 py-2 text-right text-xs text-slate-500 dark:text-slate-400">
                               {tx.original_currency
                                 ? `${tx.original_currency} ${Math.abs(tx.original_amount ?? 0).toFixed(2)}`
                                 : "-"}
@@ -372,7 +372,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                     </table>
                   </div>
                   {details[run.run_id].statement_notes && (
-                    <p className="mt-3 text-xs text-slate-500">
+                    <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
                       Notes: {details[run.run_id].statement_notes}
                     </p>
                   )}
@@ -384,7 +384,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   <button
                     type="button"
                     onClick={() => toggleDetails(run.run_id)}
-                    className="rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 min-h-11 w-full md:w-auto"
+                    className="rounded-md border border-slate-300 dark:border-slate-600 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 shadow-sm transition hover:bg-slate-100 dark:hover:bg-slate-700 min-h-11 w-full md:w-auto"
                   >
                     {expandedRun === run.run_id
                       ? "Hide transactions"
@@ -397,7 +397,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   type="button"
                   onClick={() => approve(run.run_id)}
                   disabled={approvingId === run.run_id}
-                  className="rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400 min-h-11 w-full md:w-auto"
+                  className="rounded-md bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 shadow-sm transition hover:bg-slate-800 dark:hover:bg-slate-200 disabled:cursor-not-allowed disabled:bg-slate-400 dark:disabled:bg-slate-600 min-h-11 w-full md:w-auto"
                 >
                   {approvingId === run.run_id ? "Approving..." : "Approve & commit"}
                 </button>
@@ -405,7 +405,7 @@ export default function PendingImportsView({ initialRuns }: Props) {
                   type="button"
                   onClick={() => remove(run.run_id)}
                   disabled={deletingId === run.run_id}
-                  className="rounded-md border border-red-300 px-4 py-2 text-sm font-semibold text-red-600 shadow-sm transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 min-h-11 w-full md:w-auto"
+                  className="rounded-md border border-red-300 dark:border-red-700 px-4 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm transition hover:bg-red-50 dark:hover:bg-red-900/20 disabled:cursor-not-allowed disabled:opacity-50 min-h-11 w-full md:w-auto"
                 >
                   {deletingId === run.run_id ? "Removing..." : "Discard"}
                 </button>

--- a/web/src/components/transactions/transactions-view.tsx
+++ b/web/src/components/transactions/transactions-view.tsx
@@ -92,12 +92,12 @@ interface FilterChipProps {
 
 function FilterChip({ label, value, onRemove }: FilterChipProps) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm text-slate-700">
-      <span className="text-slate-500">{label}:</span>
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 dark:bg-slate-700 px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300">
+      <span className="text-slate-500 dark:text-slate-400">{label}:</span>
       <span className="font-medium">{value}</span>
       <button
         onClick={onRemove}
-        className="ml-0.5 rounded-full p-0.5 hover:bg-slate-200 transition-colors min-h-[22px] min-w-[22px] flex items-center justify-center"
+        className="ml-0.5 rounded-full p-0.5 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors min-h-[22px] min-w-[22px] flex items-center justify-center"
         aria-label={`Remove ${label} filter`}
       >
         <XMarkIcon className="h-3.5 w-3.5" />
@@ -335,15 +335,15 @@ export default function TransactionsView({
     <div className="space-y-4 md:space-y-6">
       <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div>
-          <h1 className="text-2xl font-semibold text-slate-900">Transactions</h1>
-          <p className="text-sm text-slate-500">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Transactions</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
             Review, categorize, and annotate expenses grouped by credit card.
           </p>
         </div>
       </header>
 
       {/* Filter Section */}
-      <div className="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm overflow-hidden">
         {/* Primary Filters - Always visible */}
         <div className="p-4">
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
@@ -352,7 +352,7 @@ export default function TransactionsView({
               <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
               <input
                 type="text"
-                className="w-full rounded-md border border-slate-300 pl-9 pr-3 py-2.5 text-sm text-slate-700 placeholder:text-slate-400 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                className="w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 pl-9 pr-3 py-2.5 text-sm text-slate-700 dark:text-slate-200 placeholder:text-slate-400 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
                 placeholder="Search merchant or note..."
                 value={filters.search ?? ""}
                 onChange={(event) =>
@@ -362,10 +362,10 @@ export default function TransactionsView({
             </div>
 
             {/* Month */}
-            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Month
               <select
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
                 value={filters.month}
                 onChange={(event) =>
                   setFilters((prev) => ({ ...prev, month: event.target.value ?? "" }))
@@ -385,14 +385,14 @@ export default function TransactionsView({
                 onClick={() => setShowMoreFilters(!showMoreFilters)}
                 className={`flex items-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-colors min-h-[44px] w-full justify-center ${
                   showMoreFilters || activeAdvancedFilterCount > 0
-                    ? "bg-slate-100 text-slate-900"
-                    : "bg-slate-50 text-slate-600 hover:bg-slate-100"
+                    ? "bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-white"
+                    : "bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600"
                 }`}
               >
                 <FunnelIcon className="h-4 w-4" />
                 More Filters
                 {activeAdvancedFilterCount > 0 && (
-                  <span className="ml-1 rounded-full bg-slate-800 px-2 py-0.5 text-xs text-white">
+                  <span className="ml-1 rounded-full bg-slate-800 dark:bg-slate-600 px-2 py-0.5 text-xs text-white">
                     {activeAdvancedFilterCount}
                   </span>
                 )}
@@ -404,12 +404,12 @@ export default function TransactionsView({
 
         {/* Advanced Filters - Expandable */}
         {showMoreFilters && (
-          <div className="border-t border-slate-200 bg-slate-50 p-4">
+          <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4">
             <div className="grid gap-4 grid-cols-1 sm:grid-cols-3">
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Card
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
                   value={filters.cardId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -426,10 +426,10 @@ export default function TransactionsView({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Owner
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
                   value={filters.ownerId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -446,10 +446,10 @@ export default function TransactionsView({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+              <label className="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Category
                 <select
-                  className="mt-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
+                  className="mt-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px] focus:border-slate-500 focus:ring-1 focus:ring-slate-500 transition-colors"
                   value={filters.categoryId ?? ""}
                   onChange={(event) =>
                     setFilters((prev) => ({
@@ -472,8 +472,8 @@ export default function TransactionsView({
 
         {/* Active Filter Chips */}
         {activeFilters.length > 0 && (
-          <div className="border-t border-slate-200 px-4 py-3 flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium text-slate-500 uppercase tracking-wide mr-1">
+          <div className="border-t border-slate-200 dark:border-slate-700 px-4 py-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide mr-1">
               Active:
             </span>
             {activeFilters.map((filter) => (
@@ -486,7 +486,7 @@ export default function TransactionsView({
             ))}
             <button
               onClick={clearAllFilters}
-              className="ml-auto text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors px-2 py-1 min-h-[32px]"
+              className="ml-auto text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors px-2 py-1 min-h-[32px]"
             >
               Clear all
             </button>
@@ -495,7 +495,7 @@ export default function TransactionsView({
       </div>
 
       {errorMessage && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-600 dark:text-red-400">
           {errorMessage}
         </div>
       )}
@@ -519,24 +519,24 @@ export default function TransactionsView({
             }}
           />
         ) : (
-          <div className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500 text-center">
+          <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-sm text-slate-500 dark:text-slate-400 text-center">
             No transactions match the current filters.
           </div>
         )
       ) : (
         <div className="space-y-4 md:space-y-6">
           {groupedByCard.map(({ cardId, card, transactions: rows }) => (
-            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 bg-white p-3 md:p-4 shadow-sm">
-              <header className="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-100 pb-3 gap-2">
+            <div key={cardId} className="space-y-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 md:p-4 shadow-sm">
+              <header className="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-100 dark:border-slate-700 pb-3 gap-2">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
                     {card?.name ?? cardId}
                   </h2>
-                  <p className="text-xs uppercase tracking-wide text-slate-500">
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     {rows.length} transactions
                   </p>
                 </div>
-                <div className="text-left sm:text-right text-sm text-slate-600">
+                <div className="text-left sm:text-right text-sm text-slate-600 dark:text-slate-400">
                   <p>
                     Total spent:{" "}
                     <span className="font-medium">
@@ -565,33 +565,33 @@ export default function TransactionsView({
                 {rows.map((row) => (
                   <div
                     key={row.id}
-                    className="rounded-lg border border-slate-100 bg-slate-50 p-4 space-y-3"
+                    className="rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 p-4 space-y-3"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0 flex-1">
-                        <p className="font-medium text-slate-900 truncate">{row.merchant}</p>
+                        <p className="font-medium text-slate-900 dark:text-white truncate">{row.merchant}</p>
                         {row.description && (
-                          <p className="text-xs text-slate-500 truncate">{row.description}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400 truncate">{row.description}</p>
                         )}
                       </div>
-                      <p className="font-semibold text-slate-900 whitespace-nowrap">
+                      <p className="font-semibold text-slate-900 dark:text-white whitespace-nowrap">
                         {formatMoney(row.amount, row.currency)}
                       </p>
                     </div>
-                    <div className="flex items-center justify-between text-sm text-slate-600">
+                    <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
                       <span>{format(new Date(row.transaction_date), "dd MMM yyyy")}</span>
                       {row.original_currency && row.original_amount !== undefined && (
-                        <span className="text-xs text-slate-500">
+                        <span className="text-xs text-slate-500 dark:text-slate-400">
                           {`${row.original_currency} ${Math.abs(row.original_amount).toFixed(2)}`}
                         </span>
                       )}
                     </div>
                     <div className="grid grid-cols-2 gap-3">
-                      <label className="flex flex-col text-xs font-medium text-slate-500">
+                      <label className="flex flex-col text-xs font-medium text-slate-500 dark:text-slate-400">
                         Owner
                         <select
                           value={row.owner_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
+                          className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, { owner_id: event.target.value })
                           }
@@ -604,11 +604,11 @@ export default function TransactionsView({
                           ))}
                         </select>
                       </label>
-                      <label className="flex flex-col text-xs font-medium text-slate-500">
+                      <label className="flex flex-col text-xs font-medium text-slate-500 dark:text-slate-400">
                         Category
                         <select
                           value={row.category_id}
-                          className="mt-1 w-full rounded-md border border-slate-300 px-2 py-2 text-sm text-slate-700 min-h-[44px]"
+                          className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-2 text-sm text-slate-700 dark:text-slate-200 min-h-[44px]"
                           onChange={(event) =>
                             updateTransaction(row, {
                               category_id: event.target.value,
@@ -626,11 +626,11 @@ export default function TransactionsView({
                       </label>
                     </div>
                     {row.notes && (
-                      <p className="text-xs text-slate-600">Notes: {row.notes}</p>
+                      <p className="text-xs text-slate-600 dark:text-slate-400">Notes: {row.notes}</p>
                     )}
-                    <div className="flex justify-end pt-2 border-t border-slate-200">
+                    <div className="flex justify-end pt-2 border-t border-slate-200 dark:border-slate-600">
                       <button
-                        className="min-h-[44px] min-w-[44px] px-4 py-2 text-sm font-semibold text-red-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        className="min-h-[44px] min-w-[44px] px-4 py-2 text-sm font-semibold text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
                         onClick={() => deleteTransactionRow(row)}
                         disabled={savingId === row.id}
                       >
@@ -643,9 +643,9 @@ export default function TransactionsView({
 
               {/* Desktop table view */}
               <div className="hidden md:block overflow-x-auto">
-                <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
                   <thead>
-                    <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                    <tr className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                       <th className="px-3 py-2">Date</th>
                       <th className="px-3 py-2">Merchant</th>
                       <th className="px-3 py-2">Owner</th>
@@ -655,20 +655,20 @@ export default function TransactionsView({
                       <th className="px-3 py-2 text-right">Actions</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-slate-100 text-slate-700">
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-700 text-slate-700 dark:text-slate-300">
                     {rows.map((row) => (
-                      <tr key={row.id} className="hover:bg-slate-50">
+                      <tr key={row.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/50">
                         <td className="whitespace-nowrap px-3 py-2 font-medium">
                           {format(new Date(row.transaction_date), "dd MMM yyyy")}
                         </td>
                         <td className="px-3 py-2">
-                          <div className="font-medium text-slate-900">{row.merchant}</div>
-                          <div className="text-xs text-slate-500">{row.description}</div>
+                          <div className="font-medium text-slate-900 dark:text-white">{row.merchant}</div>
+                          <div className="text-xs text-slate-500 dark:text-slate-400">{row.description}</div>
                         </td>
                         <td className="px-3 py-2">
                           <select
                             value={row.owner_id}
-                            className="w-36 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                            className="w-36 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-2 py-1 text-xs text-slate-700 dark:text-slate-200"
                             onChange={(event) =>
                               updateTransaction(row, { owner_id: event.target.value })
                             }
@@ -684,7 +684,7 @@ export default function TransactionsView({
                         <td className="px-3 py-2">
                           <select
                             value={row.category_id}
-                            className="w-40 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                            className="w-40 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-2 py-1 text-xs text-slate-700 dark:text-slate-200"
                             onChange={(event) =>
                               updateTransaction(row, {
                                 category_id: event.target.value,
@@ -700,10 +700,10 @@ export default function TransactionsView({
                             ))}
                           </select>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-900">
+                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-900 dark:text-white">
                           {formatMoney(row.amount, row.currency)}
                           {row.original_currency && row.original_amount !== undefined && (
-                            <div className="text-xs text-slate-500">
+                            <div className="text-xs text-slate-500 dark:text-slate-400">
                               {`${row.original_currency} ${Math.abs(row.original_amount).toFixed(2)}`}
                               {row.fx_rate && row.original_currency !== row.currency ? (
                                 <span className="ml-1">({row.fx_rate.toFixed(4)} FX)</span>
@@ -711,12 +711,12 @@ export default function TransactionsView({
                             </div>
                           )}
                         </td>
-                        <td className="px-3 py-2 text-xs text-slate-600">
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-400">
                           {row.notes ?? "-"}
                         </td>
                         <td className="px-3 py-2 text-right">
                           <button
-                            className="text-xs font-semibold text-red-500 hover:text-red-600"
+                            className="text-xs font-semibold text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300"
                             onClick={() => deleteTransactionRow(row)}
                             disabled={savingId === row.id}
                           >


### PR DESCRIPTION
## Summary
- Added dark mode class variants (`dark:`) to all UI elements in transactions, imports, and pending imports pages
- Fixed white backgrounds appearing in dark mode on these pages
- Applied consistent dark mode patterns: `dark:bg-slate-800` for containers, `dark:text-white` for headings, `dark:text-slate-400` for secondary text, `dark:border-slate-700` for borders

## Test plan
- [ ] Enable dark mode toggle
- [ ] Navigate to Transactions page and verify no white backgrounds appear
- [ ] Navigate to Imports page and verify upload area, buttons, and success/error states display correctly
- [ ] Navigate to Pending Imports page and verify all cards, tables, and action buttons display correctly
- [ ] Verify warning and error states (amber/red) have proper dark mode variants

Closes #79

Generated with [Claude Code](https://claude.com/claude-code)