### PR TITLE
fix: use dynamic import for pdf-parse to avoid DOMMatrix error on Vercel

### DIFF
--- a/web/src/app/api/import/route.ts
+++ b/web/src/app/api/import/route.ts
@@ -1,7 +1,4 @@
 import { z } from "zod";
-import { PDFParse } from "pdf-parse";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 
 import { extractTransactionsWithLLM } from "@/lib/llm";
@@ -52,6 +49,11 @@ export async function POST(request: Request) {
     let statementText = data.statementText ?? "";
     if (!statementText && data.statementPdfBase64) {
       try {
+        // Dynamic imports to avoid loading pdfjs-dist browser APIs (DOMMatrix) at module load time
+        const { PDFParse } = await import("pdf-parse");
+        const path = await import("node:path");
+        const { pathToFileURL } = await import("node:url");
+
         const buffer = Buffer.from(data.statementPdfBase64, "base64");
         const workerUrl = pathToFileURL(
           path.join(process.cwd(), "node_modules/pdfjs-dist/build/pdf.worker.min.mjs"),


### PR DESCRIPTION
## Summary
- Converts top-level `pdf-parse` import to dynamic import inside the PDF processing block
- Removes unused static imports for `path` and `pathToFileURL` (now imported dynamically)
- Prevents `DOMMatrix is not defined` error when the route loads on Vercel serverless

## Problem
The `/api/import` route crashes on Vercel because `pdf-parse` is imported at the top level, which loads `pdfjs-dist` browser APIs (`DOMMatrix`) that don't exist in Node.js serverless environments.

## Solution
Dynamic imports defer loading `pdf-parse` and its dependencies until the PDF processing code actually runs, avoiding the browser API initialization at module load time.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (143 tests)
- [x] `npm run type-check` passes
- [x] `npm run lint` passes (only pre-existing warnings)

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)